### PR TITLE
fix/includes

### DIFF
--- a/package/etc/syslog-ng.conf
+++ b/package/etc/syslog-ng.conf
@@ -62,7 +62,7 @@ options {
 @include "conf.d/destinations/*.conf"
 @include "conf.d/log_paths/*.conf"
 
-@include "conf.d/local/*/filters/*.conf"
-@include "conf.d/local/*/sources/*.conf"
-@include "conf.d/local/*/destinations/*.conf"
-@include "conf.d/local/*/log_paths/*.conf"
+@include "conf.d/local/filters/*.conf"
+@include "conf.d/local/log_paths/*.conf"
+@include "conf.d/local/sources/*.conf"
+@include "conf.d/local/destinations/*.conf"


### PR DESCRIPTION
Fix syslog-ng include files to remove intermediate wildcards