### PR TITLE
Setup meta data for compliance needs by filter after source type

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,3 +45,36 @@ and variables needed to properly configure SC4S for your environment.
 SC4S_SOURCE_TLS_ENABLE=yes
 ```
 
+## Override index or metadata based on host, ip, or subnet
+
+In some cases such its appropriate to re-direct the index or append meta data such as a value of an
+indexed field to indicate PCI or regional source.
+
+* Get the template files
+```bash
+cd /opt/sc4s/default
+sudo wget https://raw.githubusercontent.com/splunk/splunk-connect-for-syslog/master/package/etc/context-local/compliance_meta_by_source.conf
+sudo wget https://raw.githubusercontent.com/splunk/splunk-connect-for-syslog/master/package/etc/context-local/compliance_meta_by_source.csv
+```
+* Edit the file ``compliance_meta_by_source.conf`` supply uniquely named filters to identify events subject to override.
+* Edit the file ``compliance_meta_by_source.csv``  using the filter name as the first field and supply an appropriate index value
+    * ``fields.fieldname`` where field name will become an indexed field
+    * ``.splunk.index`` to specify index name
+    * ``.splunk.source`` to specify a custom value for source 
+    
+* Applicable to Docker/Podman runtimes update the docker run command in the systemd unit file or the docker-compose to include volumes mapping the files above
+Unit file add the following line to the `ExecStart` command prior to `$SC4SIMAGE` then restart using the command ``sudo systemctl daemon-reload; sudo systemctl restart sc4s``
+``
+SC4S_UNIT_VP_CSV=-v /opt/sc4s/default/compliance_meta_by_source.csv:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.csv \
+SC4S_UNIT_VP_CONF=-v /opt/sc4s/default/compliance_meta_by_source.conf:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.conf \
+``
+
+* Applicable to Docker Swarm runtime update the docker compose yml to add the following volume mounts to thee sc4s service and deploy the updated service
+``docker stack deploy --compose-file docker-compose.yml sc4s``
+ 
+
+``
+      - /opt/sc4s/default/compliance_meta_by_source.csv:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.csv
+      - /opt/sc4s/default/compliance_meta_by_source.conf:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.conf
+``
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,32 +47,38 @@ SC4S_SOURCE_TLS_ENABLE=yes
 
 ## Override index or metadata based on host, ip, or subnet
 
-In some cases such its appropriate to re-direct the index or append meta data such as a value of an
-indexed field to indicate PCI or regional source.
+In some cases it is appropriate to re-direct events to an alternate index or append metadata (such as an
+indexed field) based on PCI scope, geography, or other criterion.  This is accomplished by the use
+of a file that uniquely identifies these source exceptions via syslog-ng filters,
+which maps to an associated lookup of alternate indexes, sources, or other metadata.
 
-* Get the template files
+* Get the filter and lookup files
 ```bash
 cd /opt/sc4s/default
 sudo wget https://raw.githubusercontent.com/splunk/splunk-connect-for-syslog/master/package/etc/context-local/compliance_meta_by_source.conf
 sudo wget https://raw.githubusercontent.com/splunk/splunk-connect-for-syslog/master/package/etc/context-local/compliance_meta_by_source.csv
 ```
-* Edit the file ``compliance_meta_by_source.conf`` supply uniquely named filters to identify events subject to override.
-* Edit the file ``compliance_meta_by_source.csv``  using the filter name as the first field and supply an appropriate index value
-    * ``fields.fieldname`` where field name will become an indexed field
-    * ``.splunk.index`` to specify index name
-    * ``.splunk.source`` to specify a custom value for source 
+* Edit the file ``compliance_meta_by_source.conf`` to supply uniquely named filters to identify events subject to override.
+* Edit the file ``compliance_meta_by_source.csv``  to supply appropriate the field(s) and values.
+The three columns in the table are `filter name`, `field name`, and `value`.  `field name` obeys the following convention:
+    * ``fields.fieldname`` where `fieldname` will become the name of an indexed field with the supplied value
+    * ``.splunk.index`` to specify an alternate value for index
+    * ``.splunk.source`` to specify an alternate value for source 
     
-* Applicable to Docker/Podman runtimes update the docker run command in the systemd unit file or the docker-compose to include volumes mapping the files above
-Unit file add the following line to the `ExecStart` command prior to `$SC4SIMAGE` then restart using the command ``sudo systemctl daemon-reload; sudo systemctl restart sc4s``
+* For the Docker/Podman runtimes, update the docker/podman run command in the systemd unit file or the docker-compose to
+include volumes mapping the files above.
+* In the Unit file, add the following lines to the `ExecStart` command prior to `$SC4SIMAGE` then restart using the command
+``sudo systemctl daemon-reload; sudo systemctl restart sc4s``
+
 ``
 SC4S_UNIT_VP_CSV=-v /opt/sc4s/default/compliance_meta_by_source.csv:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.csv \
 SC4S_UNIT_VP_CONF=-v /opt/sc4s/default/compliance_meta_by_source.conf:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.conf \
 ``
 
-* Applicable to Docker Swarm runtime update the docker compose yml to add the following volume mounts to thee sc4s service and deploy the updated service
+* For the Docker Swarm runtime, update the docker compose yml to add the following volume mounts to thee sc4s service and
+redeploy the updated service using the command:
 ``docker stack deploy --compose-file docker-compose.yml sc4s``
  
-
 ``
       - /opt/sc4s/default/compliance_meta_by_source.csv:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.csv
       - /opt/sc4s/default/compliance_meta_by_source.conf:/opt/syslog-ng/etc/context-local/compliance_meta_by_source.conf

--- a/package/etc/conf.d/conflib/_common/compliance_meta.conf
+++ b/package/etc/conf.d/conflib/_common/compliance_meta.conf
@@ -1,0 +1,8 @@
+parser compliance_meta_by_source {
+    add-contextual-data(
+        selector(filters("`syslog-ng-sysconfdir`/context-local/compliance_meta_by_source.conf")),
+        database("context-local/compliance_meta_by_source.csv")
+        ignore-case(yes)
+    );
+};
+

--- a/package/etc/conf.d/log_paths/p_rfc3164-cisco_asa.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-cisco_asa.conf.tmpl
@@ -17,6 +17,8 @@ log {
     rewrite { r_set_splunk_dest_default(sourcetype("cisco:asa"), index("netfw"), template("t_msg_only"))};
     parser {p_add_context_splunk(key("cisco_asa")); };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-cisco_ios.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-cisco_ios.conf.tmpl
@@ -18,6 +18,8 @@ log {
         p_add_context_splunk(key("cisco_ios"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-cisco_nx-os.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-cisco_nx-os.conf.tmpl
@@ -18,6 +18,8 @@ log {
         p_add_context_splunk(key("cisco_nx_os"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-fortinet_fortios.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-fortinet_fortios.conf.tmpl
@@ -35,6 +35,8 @@ log {
        parser {p_add_context_splunk(key("fortinet_fortios_log")); };
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_idp.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_idp.conf.tmpl
@@ -19,6 +19,8 @@ log {
                 p_add_context_splunk(key("juniper_idp"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_junos.conf.tmpl
@@ -34,6 +34,8 @@ log {
         parser {p_add_context_splunk(key("juniper_legacy")); };
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_netscreen.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_netscreen.conf.tmpl
@@ -23,6 +23,8 @@ log {
             p_add_context_splunk(key("juniper_netscreen"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
     flags(flow-control);
 };

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_nsm.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_nsm.conf.tmpl
@@ -20,6 +20,8 @@ log {
                 p_add_context_splunk(key("juniper_nsm"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
     flags(flow-control);
 };

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_nsm_idp.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_nsm_idp.conf.tmpl
@@ -19,6 +19,8 @@ log {
                 p_add_context_splunk(key("juniper_idp"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
     flags(flow-control);
 };

--- a/package/etc/conf.d/log_paths/p_rfc3164-paloalto_panos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-paloalto_panos.conf.tmpl
@@ -71,6 +71,8 @@ log {
         parser {p_add_context_splunk(key("pan_log")); };
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-proofpoint_pps_filter.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-proofpoint_pps_filter.conf.tmpl
@@ -18,6 +18,8 @@ log {
         p_add_context_splunk(key("proofpoint_pps_filter"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164-proofpoint_pps_sendmail.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-proofpoint_pps_sendmail.conf.tmpl
@@ -18,6 +18,8 @@ log {
         p_add_context_splunk(key("proofpoint_pps_sendmail"));
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc3164_microfocus_arcsight.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164_microfocus_arcsight.conf.tmpl
@@ -68,6 +68,8 @@ log {
     #CEF TAs use the source as their bounds in props.conf
     parser(p_microfocus_arcsight_source);
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc5424_noversion-cisco_asa.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc5424_noversion-cisco_asa.conf.tmpl
@@ -17,6 +17,8 @@ log {
     rewrite { r_set_splunk_dest_default(sourcetype("cisco:asa"), index("netfw"), template("t_msg_only"))};
     parser {p_add_context_splunk(key("cisco_asa")); };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc_5424_noversion-symantec_proxy.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc_5424_noversion-symantec_proxy.conf.tmpl
@@ -18,6 +18,8 @@ log {
 
     parser {p_add_context_splunk(key("bluecoat_proxy")); };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 
     flags(flow-control);

--- a/package/etc/conf.d/log_paths/p_rfc_5424_strict-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc_5424_strict-juniper_junos.conf.tmpl
@@ -37,6 +37,8 @@ log {
         parser {p_add_context_splunk(key("juniper_structured")); };
     };
 
+    parser (compliance_meta_by_source);
+
     destination(d_hec);  #--HEC--
 };
 {{- end}}

--- a/package/etc/context-local/compliance_meta_by_source.conf
+++ b/package/etc/context-local/compliance_meta_by_source.conf
@@ -1,8 +1,4 @@
-@version: 3.22
-#TODO: #60 The syntax below uses regex and an indirect reference to a variable due to a
-#bug/limitation of selector files. The better syntax should be as follows
-#filter {match("f5_test" template("$(env PRESUME_SYSLOG)")); };
-
+@version: 3.23
 filter f_test_test {
     host("something-*" type(glob)) or
     netmask(192.168.100.1/24)

--- a/package/etc/context-local/compliance_meta_by_source.conf
+++ b/package/etc/context-local/compliance_meta_by_source.conf
@@ -1,0 +1,9 @@
+@version: 3.22
+#TODO: #60 The syntax below uses regex and an indirect reference to a variable due to a
+#bug/limitation of selector files. The better syntax should be as follows
+#filter {match("f5_test" template("$(env PRESUME_SYSLOG)")); };
+
+filter f_test_test {
+    host("something-*" type(glob)) or
+    netmask(192.168.100.1/24)
+};

--- a/package/etc/context-local/compliance_meta_by_source.csv
+++ b/package/etc/context-local/compliance_meta_by_source.csv
@@ -1,0 +1,1 @@
+#f_test_test,splunk.index,"badindex"

--- a/package/etc/context-local/compliance_meta_by_source.csv
+++ b/package/etc/context-local/compliance_meta_by_source.csv
@@ -1,1 +1,2 @@
-#f_test_test,splunk.index,"badindex"
+#f_test_test,.splunk.index,"badindex"
+#f_test_test,fields.compliance,"pci"


### PR DESCRIPTION
This PR will add support using a new add-context parser that will allow a admin to add Splunk meta data (indexed fields) OR change index,source, or source type.