### PR TITLE
Updates to HEC output

### DIFF
--- a/package/etc/conf.d/destinations/splunk_hec.conf.tmpl
+++ b/package/etc/conf.d/destinations/splunk_hec.conf.tmpl
@@ -12,9 +12,9 @@ destination d_hec {
          user("sc4s")
          headers("{{- getenv "SC4S_DEST_SPLUNK_DEST_SPLUNK_HEC_HEADERS" "Connection: close"}}")
          password("{{- getenv "SPLUNK_HEC_TOKEN"}}")
-
-         {{- if eq (getenv "SC4S_DEST_SPLUNK_HEC_DISKBUFF_ENABLE" "yes") "yes"}}
          persist-name("splunk_hec")
+         {{- if eq (getenv "SC4S_DEST_SPLUNK_HEC_DISKBUFF_ENABLE" "yes") "yes"}}
+
          disk-buffer(
 
             {{- if eq (getenv "SC4S_DEST_SPLUNK_HEC_DISKBUFF_RELIABLE" "no") "yes"}}

--- a/package/etc/conf.d/destinations/splunk_hec_internal.conf.tmpl
+++ b/package/etc/conf.d/destinations/splunk_hec_internal.conf.tmpl
@@ -3,7 +3,7 @@ destination d_hec_internal {
          url("{{- getenv "SPLUNK_HEC_URL"}}")
          method("POST")
          log-fifo-size({{- getenv "SC4S_DEST_SPLUNK_HEC_LOG_FIFO_SIZE" "180000000"}})
-         workers(1)
+         workers(10)
          batch-lines({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_LINES" "1000"}})
          batch-bytes({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_BYTES" "4096kb"}})
          batch-timeout({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_TIMEOUT" "1"}})
@@ -12,7 +12,7 @@ destination d_hec_internal {
          user("sc4s")
          headers("{{- getenv "SC4S_DEST_SPLUNK_DEST_SPLUNK_HEC_HEADERS" "Connection: close"}}")
          password("{{- getenv "SPLUNK_HEC_TOKEN"}}")
-
+         persist-name("splunk_hec_internal")
 
          tls(peer-verify({{- getenv "SC4S_DEST_SPLUNK_HEC_TLS_VERIFY" "yes"}})
          {{- if ne (getenv "SC4S_DEST_SPLUNK_HEC_CIPHER_SUITE") ""}}

--- a/package/etc/conf.d/destinations/splunk_hec_metrics.conf.tmpl
+++ b/package/etc/conf.d/destinations/splunk_hec_metrics.conf.tmpl
@@ -5,12 +5,13 @@ destination d_hecmetrics {
          batch-lines(50)
          batch-bytes(1024Kb)
          batch-timeout(1)
+         workers(10)
          timeout(15)
          user_agent("sc4s/1.0 (internal metrics)")
          user("sc4s")
          headers("{{- getenv "SC4S_DEST_SPLUNK_HEC_HEADERS" "Connection: close"}}")
          password("{{- getenv "SPLUNK_HEC_TOKEN"}}")
-         persist-name("splunk_metrics")
+         persist-name("splunk_hec_metrics")
 
          tls(peer-verify({{- getenv "SC4S_DEST_SPLUNK_HEC_TLS_VERIFY" "yes"}})
          {{- if ne (getenv "SC4S_DEST_SPLUNK_HEC_CIPHER_SUITE") ""}}


### PR DESCRIPTION
- Set worker count to 10 for internal and metrics destinations
- Set Persist Name for internal to ensure data will be routed to secondary URLS when using internal load balancing.
