### PR TITLE
Fix release issues

### DIFF
--- a/docs/gettingstarted/docker-systemd-general.md
+++ b/docs/gettingstarted/docker-systemd-general.md
@@ -14,7 +14,7 @@ After=network.service
 Requires=network.service
 
 [Service]
-Environment="SC4S_IMAGE=splunk/sc4s:latest"
+Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
 

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -14,7 +14,7 @@ After=network.service
 Requires=network.service
 
 [Service]
-Environment="SC4S_IMAGE=splunk/sc4s:latest"
+Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
 


### PR DESCRIPTION
-dependabot reverted syslog-ng to downlevel 3.23.1 resolving
-docs incorrectly references the sc4s rather than scs docker registry