### PR TITLE
Update docs for env_file in getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Splunk Connect for Syslog is an open source product developed by Splunkers with 
 
 Post a question to Splunk Answers using the tag "Splunk Connect For Syslog"
 
-Join the #splunk-connect-for-syslog room in the splunk-usergroups Slack Workspace
+Join the #splunk-connect-for-syslog room in the splunk-usergroups Slack Workspace. If you don't yet have an account [sign up](https://docs.splunk.com/Documentation/Community/1.0/community/Chat)
 
 Please use the GitHub issue tracker to submit bugs or request enhancements: https://github.com/splunk/splunk-connect-for-syslog/issues
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ We welcome feedback and contributions from the community! Please see our [contri
 
 ## License
 
-Configuration and documentation licensed subject to [CC0](LICENSE-CC0)
+* Configuration and documentation licensed subject to [CC0](LICENSE-CC0)
 
-Code and scripts licensed subject to [BSD-2-Clause](LICENSE-BSD2) 
+* Code and scripts licensed subject to [BSD-2-Clause](LICENSE-BSD2) 
+
+* Third Party Red Hat Universal Base Image see [License](https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf)
+
+* Third Party Syslog-NG (OSE) [License](https://github.com/balabit/syslog-ng)
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ and variables needed to properly configure SC4S for your environment.
 * Create a folder ``/opt/sc4s/tls``
 * Save the server private key in PEM format with NO PASSWORD to ``/opt/sc4s/tls/server.key``
 * Save the server certificate in PEM format to ``/opt/sc4s/tls/server.pem``
-* Add the following line to ``/opt/sc4s/default/env_file``
+* Add the following line to ``/opt/sc4s/env_file``
 
 ```dotenv
 SC4S_SOURCE_TLS_ENABLE=yes

--- a/docs/gettingstarted/byoe-rhel7.md
+++ b/docs/gettingstarted/byoe-rhel7.md
@@ -84,7 +84,7 @@ ExecStart=/usr/sbin/syslog-ng -F $SYSLOGNG_OPTS -p /var/run/syslogd.pid
 ExecReload=/bin/kill -HUP $MAINPID
 EnvironmentFile=-/etc/default/syslog-ng
 EnvironmentFile=-/etc/sysconfig/syslog-ng
-EnvironmentFile=/opt/sc4s/default/env_file
+EnvironmentFile=/opt/sc4s/env_file
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure
@@ -125,7 +125,7 @@ mkdir -p /opt/syslog-ng/var/data/disk-buffer/
 sudo bash /opt/sc4s/bin/preconfig.sh 
 ```
 
-* Create the file ``/opt/sc4s/default/env_file`` and add the following environment variables:
+* Create the file ``/opt/sc4s/env_file`` and add the following environment variables:
 
 ```dotenv
 SYSLOGNG_OPTS=-f /opt/syslog-ng/etc/syslog-ng.conf 

--- a/docs/gettingstarted/docker-swarm-general.md
+++ b/docs/gettingstarted/docker-swarm-general.md
@@ -167,7 +167,7 @@ services:
 #     - /opt/sc4s/tls:/opt/syslog-ng/tls
 ```
 
-* Modify the following file ``/opt/sc4s/default/env_file`` to include the port-specific environment variable(s).  See the "Sources" 
+* Modify the following file ``/opt/sc4s/env_file`` to include the port-specific environment variable(s).  See the "Sources" 
 section for more information on your specific device(s).
 
 * Update ``SPLUNK_HEC_URL`` and ``SPLUNK_HEC_TOKEN`` to reflect the correct values for your environment

--- a/docs/gettingstarted/docker-swarm-rhel7.md
+++ b/docs/gettingstarted/docker-swarm-rhel7.md
@@ -196,7 +196,7 @@ services:
 #     - /opt/sc4s/tls:/opt/syslog-ng/tls
 ```
 
-* Modify the following file ``/opt/sc4s/default/env_file`` to include the port-specific environment variable(s). See the "Sources" 
+* Modify the following file ``/opt/sc4s/env_file`` to include the port-specific environment variable(s). See the "Sources" 
 section for more information on your specific device(s).
 
 * Update ``SPLUNK_HEC_URL`` and ``SPLUNK_HEC_TOKEN`` to reflect the correct values for your environment

--- a/docs/gettingstarted/docker-systemd-general.md
+++ b/docs/gettingstarted/docker-systemd-general.md
@@ -30,12 +30,12 @@ Restart=always
 
 ExecStartPre=/usr/bin/docker pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/docker run \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         --name SC4S_preflight --rm \
         $SC4S_IMAGE -s
 ExecStart=/usr/bin/docker run -p 514:514 -p 514:514/udp \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         "$SC4S_LOCAL_DISK_BUFFER_MOUNT" \
         --name SC4S --rm \
@@ -68,7 +68,7 @@ unit file above.  Failure to do this will cause SC4S to abort at startup.
 
 ## Configure the SC4S environment
 
-Create a file named ``/opt/sc4s/default/env_file`` and add the following environment variables:
+Create a file named ``/opt/sc4s/env_file`` and add the following environment variables:
 
 ```dotenv
 SPLUNK_HEC_URL=https://splunk.smg.aws:8088/services/collector/event
@@ -157,12 +157,12 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=/usr/bin/docker pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/docker run \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         --name SC4S_preflight --rm \
         $SC4S_IMAGE -s
 ExecStart=/usr/bin/docker run -p 514:514 -p 514:514/udp -p 5000-5020:5000-5020 -p 5000-5020:5000-5020/udp \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         "$SC4S_LOCAL_DISK_BUFFER_MOUNT" \
         --name SC4S \
@@ -170,7 +170,7 @@ ExecStart=/usr/bin/docker run -p 514:514 -p 514:514/udp -p 5000-5020:5000-5020 -
 $SC4S_IMAGE
 ```
 
-* Modify the following file ``/opt/sc4s/default/env_file`` to include the port-specific environment variable(s). See the "Sources" 
+* Modify the following file ``/opt/sc4s/env_file`` to include the port-specific environment variable(s). See the "Sources" 
 section for more information on your specific device(s).
 
 * Update ``SPLUNK_HEC_URL`` and ``SPLUNK_HEC_TOKEN`` to reflect the correct values for your environment

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -30,12 +30,12 @@ Restart=always
 
 ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/podman run \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         --name SC4S_preflight --rm \
         $SC4S_IMAGE -s
 ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         "$SC4S_LOCAL_DISK_BUFFER_MOUNT" \
         --name SC4S --rm \
@@ -68,7 +68,7 @@ unit file above.  Failure to do this will cause SC4S to abort at startup.
 
 ## Configure the sc4s environment
 
-Create a file named ``/opt/sc4s/default/env_file`` and add the following environment variables:
+Create a file named ``/opt/sc4s/env_file`` and add the following environment variables:
 
 ```dotenv
 SPLUNK_HEC_URL=https://splunk.smg.aws:8088/services/collector/event
@@ -157,12 +157,12 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/podman run \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         --name SC4S_preflight --rm \
         $SC4S_IMAGE -s
 ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 5000-5020:5000-5020 -p 5000-5020:5000-5020/udp \
-        --env-file=/opt/sc4s/default/env_file \
+        --env-file=/opt/sc4s/env_file \
         "$SC4S_LOCAL_CONFIG_MOUNT" \
         "$SC4S_LOCAL_DISK_BUFFER_MOUNT" \
         --name SC4S \
@@ -170,7 +170,7 @@ ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 5000-5020:5000-5020 -
 $SC4S_IMAGE
 ```
 
-* Modify the following file ``/opt/sc4s/default/env_file`` to include the port-specific environment variable(s). See the "Sources" 
+* Modify the following file ``/opt/sc4s/env_file`` to include the port-specific environment variable(s). See the "Sources" 
 section for more information on your specific device(s).
 
 * Update ``SPLUNK_HEC_URL`` and ``SPLUNK_HEC_TOKEN`` to reflect the correct values for your environment

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,21 @@ HTTP event Collector.
 * Reduce latency and improve scale by balancing event distribution across Splunk Indexers
 
 
+## Support
+
+Splunk Connect for Syslog is an open source product developed by Splunkers with contributions from the community of partners and customers. This unique product will be enhanced, maintained and supported by the community, led by Splunkers with deep subject matter expertise. The primary reason why Splunk is taking this approach is to push product development closer to those that use and depend upon it. This direct connection will help us all be more successful and move at a rapid pace.
+
+Post a question to Splunk Answers using the tag "Splunk Connect For Syslog"
+
+Join the #splunk-connect-for-syslog room in the splunk-usergroups Slack Workspace. If you don't yet have an account [sign up](https://docs.splunk.com/Documentation/Community/1.0/community/Chat)
+
+Please use the GitHub issue tracker to submit bugs or request enhancements: https://github.com/splunk/splunk-connect-for-syslog/issues
+
+Get involved, try it out, ask questions, contribute filters, and make new friends!
+
+## Contributing
+
+We welcome feedback and contributions from the community! Please see our [contribution guidelines](CONTRIBUTING.md) for more information on how to get involved.
 
 ## License
 


### PR DESCRIPTION
This change makes the location of env_file consistent however this is a procedural breaking change a deployment using the earlier docs will have the file in the wrong place. Users should move the file from opt/sc4s/default/env_file to opt/sc4s/env_file and revise the sc4s.service file to correct