### PR TITLE
fix/startup_warnings

### DIFF
--- a/package/etc/context_templates/compliance_meta_by_source.conf
+++ b/package/etc/context_templates/compliance_meta_by_source.conf
@@ -1,5 +1,6 @@
 @version: 3.24
-#filter f_test_test {
-#    host("something-*" type(glob)) or
-#    netmask(192.168.100.1/24)
-#};
+filter f_test_test {
+#   host("something-*" type(glob)) or
+#   netmask(169.254.100.0/24)
+    host("cannot_ever_happen")
+};

--- a/package/etc/context_templates/compliance_meta_by_source.csv
+++ b/package/etc/context_templates/compliance_meta_by_source.csv
@@ -1,2 +1,2 @@
-#f_test_test,.splunk.index,"badindex"
-#f_test_test,fields.compliance,"pci"
+f_test_test,.splunk.index,"will_never_happen_index"
+f_test_test,fields.compliance,"pci"


### PR DESCRIPTION
Fix startup warnings caused by (illegal) comments in csv files

#163 