### PR TITLE
Upgrade image from UBI7 to UBI8

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,35 +6,27 @@
 #
 #You should have received a copy of the CC0 legalcode along with this
 #work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-FROM registry.access.redhat.com/rhel7/rhel
+FROM centos:centos8
 
-ARG RH_ORG
-ARG RH_ACTIVATION
 
-ENV CONFIGURE_FLAGS="--prefix=/opt/syslog-ng --with-ivykis=system --with-jsonc=system --disable-env-wrapper --disable-memtrace --enable-tcp-wrapper --disable-linux-caps --disable-man-pages --enable-all-modules --enable-force-gnu99 --enable-json --enable-native --enable-python --enable-http --enable-kafka --disable-java --disable-java-modules --disable-spoof_source --disable-sun_streams --disable-sql --disable-pacct --disable-mongodb --disable-amqp --disable-stomp --disable-redis --disable-systemd --disable-geoip --disable-geoip2 --disable-riemann --disable-smtp --disable-snmp_dest --with-python=3 --enable-dynamic-linking"
+ENV CONFIGURE_FLAGS="--prefix=/opt/syslog-ng --with-ivykis=system --with-jsonc=system --disable-env-wrapper --disable-memtrace --disable-tcp-wrapper --disable-linux-caps --disable-man-pages --enable-all-modules --enable-force-gnu99 --enable-json --enable-native --enable-python --enable-http --disable-kafka --disable-java --disable-java-modules --disable-spoof_source --disable-sun_streams --disable-sql --disable-pacct --disable-mongodb --disable-amqp --disable-stomp --disable-redis --disable-systemd --disable-geoip --disable-geoip2 --disable-riemann --disable-smtp --disable-snmp_dest --with-python=3 --enable-dynamic-linking"
 
-ENV DISTCHECK_CONFIGURE_FLAGS="--prefix=/opt/syslog-ng --with-ivykis=system --with-jsonc=system --disable-env-wrapper --disable-memtrace --enable-tcp-wrapper --disable-linux-caps --disable-man-pages --enable-all-modules --enable-force-gnu99 --enable-json --enable-native --enable-python --enable-http --enable-kafka --disable-java --disable-java-modules --disable-spoof_source --disable-sun_streams --disable-sql --disable-pacct --disable-mongodb --disable-amqp --disable-stomp --disable-redis --disable-systemd --disable-geoip --disable-geoip2 --disable-riemann --disable-smtp --disable-snmp_dest --with-python=3 --enable-dynamic-linking"
-COPY confluent.repo /etc/yum.repos.d/confluent.repo
-RUN subscription-manager register --org=$RH_ORG --activationkey=$RH_ACTIVATION --force
-RUN subscription-manager repos --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-optional-rpms --enable=rhel-server-rhscl-7-rpms
-RUN yum update -y; yum install wget -y
-RUN rpm --import https://packages.confluent.io/rpm/5.2/archive.key
-RUN cd /tmp ;\
-    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm ;\
-    yum install epel-release-latest-7.noarch.rpm -y ;\
-    rm epel-release-latest-7.noarch.rpm
-RUN yum install findutils autoconf \
-    autoconf-archive automake ca-certificates git libtool pkgconfig bison byacc file \
-    flex pcre-devel glib2-devel openssl-devel librdkafka-devel libcurl-devel \
-    rh-python36 rh-python36-python-tools rh-python36-scldevel\
+ENV DISTCHECK_CONFIGURE_FLAGS="--prefix=/opt/syslog-ng --with-ivykis=system --with-jsonc=system --disable-env-wrapper --disable-memtrace --disable-tcp-wrapper --disable-linux-caps --disable-man-pages --enable-all-modules --enable-force-gnu99 --enable-json --enable-native --enable-python --enable-http --disable-kafka --disable-java --disable-java-modules --disable-spoof_source --disable-sun_streams --disable-sql --disable-pacct --disable-mongodb --disable-amqp --disable-stomp --disable-redis --disable-systemd --disable-geoip --disable-geoip2 --disable-riemann --disable-smtp --disable-snmp_dest --with-python=3 --enable-dynamic-linking"
+
+RUN dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y ;\
+    dnf install 'dnf-command(config-manager)' -y ;\
+    dnf config-manager --set-enabled PowerTools -y; \
+    dnf update -y
+
+RUN dnf group install "Development Tools" ;\
+    dnf install findutils autoconf \
+    autoconf automake ca-certificates git libtool pkgconfig bison byacc file \
+    flex pcre-devel glib2-devel openssl-devel libcurl-devel \
+    python3 python3-devel \
     net-snmp-devel \
-    libuuid-devel cmake make libxslt docbook-style-xsl gcc-c++ tzdata libxml2 sqlite \
-    json-c-devel gnupg wget curl which bzip2 doxygen libsecret ivykis-devel -y
+    libuuid-devel cmake make libxslt gcc-c++ tzdata libxml2 sqlite \
+    gnupg wget curl which bzip2 libsecret ivykis-devel autoconf-archive json-c-devel -y
 
-RUN subscription-manager unregister
-
-RUN echo source scl_source enable rh-python36 >>/etc/profile.d/enablepython36.sh ;\
-    source scl_source enable rh-python36
 
 RUN CRITERION_VERSION=2.3.3 ;\
     cd /tmp/;\
@@ -48,32 +40,24 @@ RUN CRITERION_VERSION=2.3.3 ;\
 
 COPY syslog-ng /work
 
-RUN source scl_source enable rh-python36 ;\
-    cd /work;\
-    pip install -r requirements.txt ;\
+RUN cd /work;\
+    pip3 install -r requirements.txt ;\
     ./autogen.sh ;\
     ./configure $CONFIGURE_FLAGS ;\
     make -j -l 2.5 install
 
 
-FROM registry.access.redhat.com/ubi7/ubi
-
-COPY confluent.repo /etc/yum.repos.d/confluent.repo
+FROM registry.redhat.io/ubi8/ubi
 
 RUN cd /tmp ;\
-    yum install -y wget ;\
-    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm ;\
-    yum install epel-release-latest-7.noarch.rpm -y ;\
-    rm epel-release-latest-7.noarch.rpm ;\
-    rpm --import https://packages.confluent.io/rpm/5.2/archive.key ;\
-    yum install gcc tzdata libdbi libsecret libxml2 sqlite tcp_wrappers librdkafka \
-    rh-python36 rh-python36-python-tools libcurl ivykis scl-utils tcp_wrappers-libs curl wget openssl -y;\
-    echo source scl_source enable rh-python36 >>/etc/profile.d/enablepython36.sh ;\
-    source scl_source enable rh-python36
+    dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y; \
+    dnf update -y ;\
+    dnf install wget gcc tzdata libdbi libsecret libxml2 sqlite \
+    python3 libcurl ivykis scl-utils curl wget openssl -y
 
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
-RUN source scl_source enable rh-python36 ; curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.7 sh
+RUN curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.7 sh
 COPY goss.yaml /etc/goss.yaml
 
 COPY --from=0 /opt/syslog-ng /opt/syslog-ng

--- a/package/confluent.repo
+++ b/package/confluent.repo
@@ -8,14 +8,14 @@
 #work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 [Confluent.dist]
 name=Confluent repository (dist)
-baseurl=https://packages.confluent.io/rpm/5.2/7
+baseurl=https://packages.confluent.io/rpm/5.3/7
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.2/archive.key
+gpgkey=https://packages.confluent.io/rpm/5.3/archive.key
 enabled=1
 
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/5.2
+baseurl=https://packages.confluent.io/rpm/5.3
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.2/archive.key
+gpgkey=https://packages.confluent.io/rpm/5.3/archive.key
 enabled=1


### PR DESCRIPTION
This switch will also remove kafka support from the image. At this time confluent nor EPEL contain a current conpatible version of the librarys