### PR TITLE
json events not formatted in fallback

### DIFF
--- a/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
@@ -6,6 +6,7 @@ log {
         rewrite {
             r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main"));
             set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
+            unset(value("RAWMSG"));
         };
         parser {
             p_add_context_splunk(key("sc4s_fallback"));
@@ -14,12 +15,6 @@ log {
         destination(d_hec);
     {{- end}}
 
-
-        #in fallback archive only write rawmsg as msg
-        rewrite {
-            unset(value("RAWMSG"));
-            groupunset(values(".kv.*"));
-        };
 
     {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
         destination(d_archive);

--- a/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
@@ -3,50 +3,55 @@ log {
 
     if {
         filter(f_is_rfc5424_strict);
-        rewrite { r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main")); };
-        parser { p_add_context_splunk(key("sc4s_fallback")); };
-        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_JSON_5424))" value("MSG")); };
-    {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_FALLBACK_HEC" "no")) }}
+        rewrite {
+            r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main"));
+            set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
+        };
+        parser {
+            p_add_context_splunk(key("sc4s_fallback"));
+        };
+    {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
         destination(d_hec);
     {{- end}}
 
 
-{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_FALLBACK" "no")) }}
-
-        #in fallback archive write rawmsg as msg
+        #in fallback archive only write rawmsg as msg
         rewrite {
-            set("$RAWMSG" value("MSG"));
             unset(value("RAWMSG"));
             groupunset(values(".kv.*"));
         };
+
+    {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
         destination(d_archive);
     {{- end}}
 
     } else {
-        rewrite { r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main")); };
-        parser { p_add_context_splunk(key("sc4s_fallback")); };
-        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG")); };
 
-    {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_FALLBACK_HEC" "no")) }}
-        destination(d_hec);
-    {{- end}}
-
-
-{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_FALLBACK" "no")) }}
-
-        #in fallback archive write rawmsg as msg
         rewrite {
-            set("$RAWMSG" value("MSG"));
+            r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main") );
+            set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
             unset(value("RAWMSG"));
             unset(value("PROGRAM"));
             unset(value("LEGACY_MSGHDR"));
             groupunset(values(".kv.*"));
         };
-        destination(d_archive);
+        parser {
+            p_add_context_splunk(key("sc4s_fallback"));
+        };
 
-    {{- end}}
+        {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
+            destination(d_hec);
+        {{- end}}
 
+
+        #in fallback archive only write rawmsg as msg
+
+        {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
+            destination(d_archive);
+        {{- end}}
     };
+
+
 
     flags(flow-control,fallback);
 };

--- a/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
@@ -26,31 +26,29 @@ log {
     {{- end}}
 
     } else {
+
         rewrite {
             r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main") );
             set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
-        };
-        parser {
-            p_add_context_splunk(key("sc4s_fallback"));
-        };
-
-    {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
-        destination(d_hec);
-    {{- end}}
-
-
-        #in fallback archive only write rawmsg as msg
-        rewrite {
-            set("$RAWMSG" value("MSG"));
             unset(value("RAWMSG"));
             unset(value("PROGRAM"));
             unset(value("LEGACY_MSGHDR"));
             groupunset(values(".kv.*"));
         };
+        parser {
+            p_add_context_splunk(key("sc4s_fallback"));
+        };
 
-    {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
-        destination(d_archive);
-    {{- end}}
+        {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
+            destination(d_hec);
+        {{- end}}
+
+
+        #in fallback archive only write rawmsg as msg
+
+        {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
+            destination(d_archive);
+        {{- end}}
     };
 
 

--- a/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
@@ -5,7 +5,7 @@ log {
         filter(f_is_rfc5424_strict);
         rewrite {
             r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main"));
-            set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
+            set("$(template ${.splunk.sc4s_template} $(template t_JSON_5424))" value("MSG"));
             unset(value("RAWMSG"));
         };
         parser {

--- a/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_zz_fallback.conf.tmpl
@@ -3,55 +3,50 @@ log {
 
     if {
         filter(f_is_rfc5424_strict);
-        rewrite {
-            r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main"));
-            set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
-        };
-        parser {
-            p_add_context_splunk(key("sc4s_fallback"));
-        };
-    {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
+        rewrite { r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main")); };
+        parser { p_add_context_splunk(key("sc4s_fallback")); };
+        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_JSON_5424))" value("MSG")); };
+    {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_FALLBACK_HEC" "no")) }}
         destination(d_hec);
     {{- end}}
 
 
-        #in fallback archive only write rawmsg as msg
+{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_FALLBACK" "no")) }}
+
+        #in fallback archive write rawmsg as msg
         rewrite {
+            set("$RAWMSG" value("MSG"));
             unset(value("RAWMSG"));
             groupunset(values(".kv.*"));
         };
-
-    {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
         destination(d_archive);
     {{- end}}
 
     } else {
+        rewrite { r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main")); };
+        parser { p_add_context_splunk(key("sc4s_fallback")); };
+        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG")); };
 
+    {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_FALLBACK_HEC" "no")) }}
+        destination(d_hec);
+    {{- end}}
+
+
+{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_FALLBACK" "no")) }}
+
+        #in fallback archive write rawmsg as msg
         rewrite {
-            r_set_splunk_dest_default(sourcetype("sc4s:fallback"), index("main") );
-            set("$(template ${.splunk.sc4s_template} $(template t_JSON))" value("MSG"));
+            set("$RAWMSG" value("MSG"));
             unset(value("RAWMSG"));
             unset(value("PROGRAM"));
             unset(value("LEGACY_MSGHDR"));
             groupunset(values(".kv.*"));
         };
-        parser {
-            p_add_context_splunk(key("sc4s_fallback"));
-        };
+        destination(d_archive);
 
-        {{- if ((getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes") | conv.ToBool) or (conv.ToBool (getenv "SC4S_DEST_ARCHIVE_HEC" "no") | conv.ToBool) }}
-            destination(d_hec);
-        {{- end}}
+    {{- end}}
 
-
-        #in fallback archive only write rawmsg as msg
-
-        {{- if (getenv "SC4S_ARCHIVE_GLOBAL") or (getenv "SC4S_ARCHIVE_FALLBACK") }}
-            destination(d_archive);
-        {{- end}}
     };
-
-
 
     flags(flow-control,fallback);
 };

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -22,7 +22,7 @@ def test_defaultroute(record_property, setup_wordlist, setup_splunk):
 
     sendsingle(message)
 
-    st = env.from_string("search index=main host=\"{{ host }}\" sourcetype=\"sc4s:fallback\" | head 2")
+    st = env.from_string("search index=main host=\"{{ host }}\" sourcetype=\"sc4s:fallback\" PROGRAM=\"test\" | head 2")
     search = st.render(host=host)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)


### PR DESCRIPTION
resolve unexpected behaior with syslog-ng out of order processing of directives impacting the hec format for json fallback due to archive support. Add test condition to ensure this doesn't break again