### PR TITLE
Markdown and formatting update

### DIFF
--- a/docs/gettingstarted/byoe-rhel7.md
+++ b/docs/gettingstarted/byoe-rhel7.md
@@ -160,7 +160,7 @@ sudo systemctl start sc4s
 ## Configure SC4S Listening Ports
 
 Most enterprises use UDP/TCP port 514 as the default as their main listening port for syslog "soup" traffic, and TCP port 6514 for TLS.
-The docker compose file and standard SC4S configurations reflect these defaults.  These defaults can be changed by adding the following
+The standard SC4S configuration reflect these defaults.  These defaults can be changed by adding the following
 additional environment variables with appropriate values to the ``env_file`` above:
 ```dotenv
 SC4S_LISTEN_DEFAULT_TCP_PORT=514
@@ -170,7 +170,7 @@ SC4S_LISTEN_DEFAULT_TLS_PORT=6514
 ### Dedicated (Unique) Listening Ports
 
 For certain source technologies, categorization by message content is impossible due to the lack of a unique "fingerprint" in
-the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.  
+the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.
 For collection of such sources we provide a means of dedicating a unique listening port to a specific source.
 
 Refer to the "Sources" documentation to identify the specific environment variables used to enable unique listening ports for the technology

--- a/docs/gettingstarted/docker-swarm-general.md
+++ b/docs/gettingstarted/docker-swarm-general.md
@@ -135,7 +135,7 @@ No changes to the underlying SC4S default configuration (environment variables) 
 ### Dedicated (Unique) Listening Ports
 
 For certain source technologies, categorization by message content is impossible due to the lack of a unique "fingerprint" in
-the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.  
+the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.
 For collection of such sources, we provide a means of dedicating a unique listening port to a specific source.
 
 The docker compose file used to start the SC4S container needs to be modified as well to reflect the additional listening ports configured
@@ -219,10 +219,6 @@ the files above, where the `conf` file specifies a filter to uniquely identify t
 lists one or more metadata items that can be overridden based on the filter name.  This is an advanced topic, and further information is
 covered in the "Override index or metadata based on host, ip, or subnet" section of the Configuration document.
 
-# Scale out
-
-Additional hosts can be deployed for syslog collection from additional network zones and locations.
-
 # Start/Restart SC4S
 
 ```bash
@@ -249,7 +245,7 @@ index=* sourcetype=sc4s:events "starting up"
 ```
 This should yield the following event:
 ```ini
-syslog-ng starting up; version='3.22.1'
+syslog-ng starting up; version='3.25.1'
 ``` 
 when the startup process proceeds normally (without syntax errors). If you do not see this,
 follow the steps below before proceeding to deeper-level troubleshooting:

--- a/docs/gettingstarted/docker-swarm-rhel7.md
+++ b/docs/gettingstarted/docker-swarm-rhel7.md
@@ -143,7 +143,7 @@ No changes to the underlying SC4S default configuration (environment variables) 
 ### Dedicated (Unique) Listening Ports
 
 For certain source technologies, categorization by message content is impossible due to the lack of a unique "fingerprint" in
-the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.  
+the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.
 For collection of such sources, we provide a means of dedicating a unique listening port to a specific source.
 
 The docker compose file used to start the SC4S container needs to be modified as well to reflect the additional listening ports configured
@@ -227,10 +227,6 @@ the files above, where the `conf` file specifies a filter to uniquely identify t
 lists one or more metadata items that can be overridden based on the filter name.  This is an advanced topic, and further information is
 covered in the "Override index or metadata based on host, ip, or subnet" section of the Configuration document.
 
-# Scale out
-
-Additional hosts can be deployed for syslog collection from additional network zones and locations.
-
 # Start/Restart SC4S
 
 ```bash
@@ -257,7 +253,7 @@ index=* sourcetype=sc4s:events "starting up"
 ```
 This should yield the following event:
 ```ini
-syslog-ng starting up; version='3.22.1'
+syslog-ng starting up; version='3.25.1'
 ``` 
 when the startup process proceeds normally (without syntax errors). If you do not see this,
 follow the steps below before proceeding to deeper-level troubleshooting:

--- a/docs/gettingstarted/docker-systemd-general.md
+++ b/docs/gettingstarted/docker-systemd-general.md
@@ -35,11 +35,9 @@ After=network.target network-online.target
 Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
-
 Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.d/local:z"
 
 # Optional mount point for local disk archive (EWMM output) files
-
 # Environment="SC4S_LOCAL_ARCHIVE_MOUNT=-v /opt/sc4s/archive:/opt/syslog-ng/var/archive:z"
 
 # Mount point for local disk buffer (required)
@@ -135,7 +133,7 @@ on the _container_.  No changes to the underlying SC4S default configuration (en
 ### Dedicated (Unique) Listening Ports
 
 For certain source technologies, categorization by message content is impossible due to the lack of a unique "fingerprint" in
-the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.  
+the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.
 For collection of such sources, we provide a means of dedicating a unique listening port to a specific source.
 
 The unit file used to start the SC4S container needs to be modified as well to reflect the additional listening ports configured by the
@@ -158,11 +156,9 @@ Requires=network.service
 Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
-
 Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.d/local:z"
 
 # Optional mount point for local disk archive (EWMM output) files
-
 # Environment="SC4S_LOCAL_ARCHIVE_MOUNT=-v /opt/sc4s/archive:/opt/syslog-ng/var/archive:z"
 
 # Mount point for local disk buffer (required)
@@ -263,7 +259,7 @@ index=* sourcetype=sc4s:events "starting up"
 ```
 This should yield the following event:
 ```ini
-syslog-ng starting up; version='3.22.1'
+syslog-ng starting up; version='3.25.1'
 ``` 
 when the startup process proceeds normally (without syntax errors). If you do not see this,
 follow the steps below before proceeding to deeper-level troubleshooting:
@@ -281,7 +277,7 @@ docker logs SC4S
 ```
 You should see events similar to those below in the output:
 ```ini
-Oct  1 03:13:35 77cd4776af41 syslog-ng[1]: syslog-ng starting up; version='3.24.1'
+Oct  1 03:13:35 77cd4776af41 syslog-ng[1]: syslog-ng starting up; version='3.25.1'
 Oct  1 05:29:55 77cd4776af41 syslog-ng[1]: Syslog connection accepted; fd='49', client='AF_INET(10.0.1.18:55010)', local='AF_INET(0.0.0.0:514)'
 Oct  1 05:29:55 77cd4776af41 syslog-ng[1]: Syslog connection closed; fd='49', client='AF_INET(10.0.1.18:55010)', local='AF_INET(0.0.0.0:514)'
 ```

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -17,11 +17,9 @@ After=network.target network-online.target
 Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
-
 Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.d/local:z"
 
 # Optional mount point for local disk archive (EWMM output) files
-
 # Environment="SC4S_LOCAL_ARCHIVE_MOUNT=-v /opt/sc4s/archive:/opt/syslog-ng/var/archive:z"
 
 # Mount point for local disk buffer (required)
@@ -117,7 +115,7 @@ on the _container_.  No changes to the underlying SC4S default configuration (en
 ### Dedicated (Unique) Listening Ports
 
 For certain source technologies, categorization by message content is impossible due to the lack of a unique "fingerprint" in
-the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.  
+the data.  In other cases, a unique listening port is required for certain devices due to network requirements in the enterprise.
 For collection of such sources, we provide a means of dedicating a unique listening port to a specific source.
 
 The unit file used to start the SC4S container needs to be modified as well to reflect the additional listening ports configured by the
@@ -140,11 +138,9 @@ Requires=network.service
 Environment="SC4S_IMAGE=splunk/scs:latest"
 
 # Optional mount point for local overrides and configurations; see notes in docs
-
 Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.d/local:z"
 
 # Optional mount point for local disk archive (EWMM output) files
-
 # Environment="SC4S_LOCAL_ARCHIVE_MOUNT=-v /opt/sc4s/archive:/opt/syslog-ng/var/archive:z"
 
 # Mount point for local disk buffer (required)
@@ -245,7 +241,7 @@ index=* sourcetype=sc4s:events "starting up"
 ```
 This should yield the following event:
 ```ini
-syslog-ng starting up; version='3.22.1'
+syslog-ng starting up; version='3.25.1'
 ``` 
 when the startup process proceeds normally (without syntax errors). If you do not see this,
 follow the steps below before proceeding to deeper-level troubleshooting:
@@ -263,7 +259,7 @@ podman logs SC4S
 ```
 You should see events similar to those below in the output:
 ```ini
-Oct  1 03:13:35 77cd4776af41 syslog-ng[1]: syslog-ng starting up; version='3.24.1'
+Oct  1 03:13:35 77cd4776af41 syslog-ng[1]: syslog-ng starting up; version='3.25.1'
 Oct  1 05:29:55 77cd4776af41 syslog-ng[1]: Syslog connection accepted; fd='49', client='AF_INET(10.0.1.18:55010)', local='AF_INET(0.0.0.0:514)'
 Oct  1 05:29:55 77cd4776af41 syslog-ng[1]: Syslog connection closed; fd='49', client='AF_INET(10.0.1.18:55010)', local='AF_INET(0.0.0.0:514)'
 ```


### PR DESCRIPTION
* Remove extra spaces at end of sentences; affects md rendering
* Remove extra blank lines from Unit file examples for readability
* Update all version strings to 3.25.1
* Remove extra "Scale Out" section from runtime docs (covered elsewhere)