### PR TITLE
Fix output template for Palo Alto log path

### DIFF
--- a/package/etc/conf.d/log_paths/p_rfc3164-paloalto_panos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-paloalto_panos.conf.tmpl
@@ -77,7 +77,7 @@ log {
     };
 
     parser (compliance_meta_by_source);
-    rewrite { set("$(template ${.splunk.sc4s_template} $(template t_hdr_msg))" value("MSG")); };
+    rewrite { set("$(template ${.splunk.sc4s_template} $(template t_msg_only))" value("MSG")); };
 
 {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_PALOALTO_PANOS_HEC" "no")) }}
     destination(d_hec);


### PR DESCRIPTION
* Change output template from `t_hdr_msg` to `t_msg_only` for Palo Alto log path to account for removed "unset" config element