### PR TITLE
Rename log paths and update with junction/channel architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@
 #work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 version: 2.1
 orbs:
-  docker: circleci/docker@0.5.13
+  docker: circleci/docker@0.5.20
   go: circleci/go@0.2.0
   snyk: snyk/snyk@0.0.8
   versioning: kollex/versioning@1.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - versioning/create_version_file:
          version_file_path: /tmp/workspace/VERSION
 
-      #- docker/install-docker
+      - docker/install-docker
       - docker/check:
           registry: $REGISTRY
           docker-username: GITHUB_USER
@@ -94,7 +94,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init --recursive
 
-      - docker/install-docker-tools
+      #- docker/install-docker-tools
       - docker/check:
           registry: $REGISTRY
           docker-username: GITHUB_USER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - versioning/create_version_file:
          version_file_path: /tmp/workspace/VERSION
 
-      - docker/install-docker
+      #- docker/install-docker
       - docker/check:
           registry: $REGISTRY
           docker-username: GITHUB_USER

--- a/package/etc/conf.d/local/config/log_paths/lp-example.conf.tmpl
+++ b/package/etc/conf.d/local/config/log_paths/lp-example.conf.tmpl
@@ -29,24 +29,23 @@
 {{- $context := dict "port_id" "LOCAL_EXAMPLE" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-
-{{- /* The first time this template is used the log_path will be linked to the default port */}}
-
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_local_example);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for LOCAL_EXAMPLE traffic
+            source (s_LOCAL_EXAMPLE);
+            flags (final);
+	    };
 {{- end}}
-
-{{- /* In the second pass through the template a link to the dedicated port is used. This */}}
-{{- /* normally does not require additional filters */}}
-
-{{- if eq (.) "no"}}
-    source (s_LOCAL_EXAMPLE);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for LOCAL_EXAMPLE traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_local_example);
+            flags(final);
+        };
+    };
 
 # Set a default sourcetype and index, as well as an appropriate value for the field
 # "sc4s_vendor_product".  This field is sent as an indexed field to Splunk,
@@ -87,15 +86,3 @@ log {
 # All passes through any matching log path will be final
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- /* Prepare to run two passes through this template, one for default traffic and another for */}}
-{{- /* "unique ports" if they are configured. */}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for LOCAL_EXAMPLE traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end }}
-
-# Listen on the default port (typically 514) for LOCAL_EXAMPLE traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "CHECKPOINT_SPLUNK" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_checkpoint_splunk);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CHECKPOINT_SPLUNK traffic
+            source (s_CHECKPOINT_SPLUNK);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CHECKPOINT_SPLUNK);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CHECKPOINT_SPLUNK traffic
+            source(s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_checkpoint_splunk);
+            flags(final);
+        };
+    };
 
     if {
         filter(f_nix_syslog);
@@ -84,11 +90,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-{{- if or (or (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CHECKPOINT_SPLUNK_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for CHECKPOINT_SPLUNK traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CHECKPOINT_SPLUNK traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_acs.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_acs.conf.tmpl
@@ -46,17 +46,24 @@ parser acs_event_time {
             template("${ACS.DATE} ${ACS.TIME} ${ACS.TZ}")
     );
 };
-{{- /* The following is an inline template to generate the actual log path */}}
-{{ define "log_path" }}
+
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_cisco_acs);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_NX_OS traffic
+            source (s_CISCO_NX_OS);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CISCO_ACS);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_NX_OS traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_cisco_acs);
+            flags(final);
+        };
+    };
 
     parser(acs_grouping);
 
@@ -83,15 +90,4 @@ log {
         flags(flow-control,final);
     };
 
-
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ACS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ACS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ACS_TLS_PORT")) }}
-
-# Listen on the specified dedicated port(s) for CISCO_ACS traffic
-    {{tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_ACS traffic
-{{tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_asa.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_asa.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "CISCO_ASA" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc5424_noversion);
-    filter(f_cisco_asa);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ASA_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ASA_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ASA_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_ASA traffic
+            source (s_CISCO_ASA);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CISCO_ASA);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_ASA traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc5424_noversion);
+            filter(f_cisco_asa);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("cisco_asa", value("fields.sc4s_vendor_product"));
@@ -33,12 +39,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ASA_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ASA_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ASA_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for CISCO_ASA traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_ASA traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_asa_legacy.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_asa_legacy.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "CISCO_ASA_LEGACY" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_cisco_asa);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_ASA_LEGACY traffic
+            source (s_CISCO_ASA_LEGACY);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CISCO_ASA_LEGACY);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_ASA_LEGACY traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_cisco_asa);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("cisco_asa", value("fields.sc4s_vendor_product"));
@@ -31,16 +37,5 @@ log {
     destination(d_archive);
 {{- end}}
 
-
     flags(flow-control,final);
-
 };
-{{- end}}
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ASA_LEGACY_TLS_PORT")) }}
-
-# Listen on the specified dedicated port(s) for CISCO_ASA_LEGACY traffic
-    {{tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_ASA_LEGACY traffic
-{{tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_ios.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ios.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "CISCO_IOS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter(f_is_cisco_ios);
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_CISCO_IOS);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_IOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_IOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_IOS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_IOS traffic
+            source (s_CISCO_IOS);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_IOS traffic
+            source (s_DEFAULT);
+            filter(f_is_cisco_ios);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("cisco_ios", value("fields.sc4s_vendor_product"));
@@ -33,12 +39,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_IOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_IOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_IOS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for CISCO_IOS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_IOS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
@@ -1,6 +1,6 @@
 # Cisco ISE
 {{- /* The following provides a unique port source configuration if env var(s) are set */}}
-{{- $context := dict "port_id" "CISCO_NX_OS" "parser" "common" }}
+{{- $context := dict "port_id" "CISCO_ISE" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
 # This filter uses a field we set to prevent the original messages before aggregation from being
@@ -48,17 +48,24 @@ parser ise_event_time {
             template("${ISE.DATE} ${ISE.TIME} ${ISE.TZ}")
     );
 };
-{{- /* The following is an inline template to generate the actual log path */}}
-{{ define "log_path" }}
+
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_cisco_ise);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ISE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ISE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ISE_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_ISE traffic
+            source (s_CISCO_ISE);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CISCO_ISE);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_ISE traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_cisco_ise);
+            flags(final);
+        };
+    };
 
     parser(ise_grouping);
 
@@ -86,13 +93,3 @@ log {
     };
 
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_ISE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_ISE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_ISE_TLS_PORT")) }}
-
-# Listen on the specified dedicated port(s) for CISCO_ISE traffic
-    {{tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_ISE traffic
-{{tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-cisco_nxos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_nxos.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "CISCO_NX_OS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter(f_cisco_nx_os);
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_CISCO_NX_OS);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_NX_OS traffic
+            source (s_CISCO_NX_OS);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_NX_OS traffic
+            source (s_DEFAULT);
+            filter(f_cisco_nx_os);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("cisco_nxos", value("fields.sc4s_vendor_product"));
@@ -32,15 +38,5 @@ log {
     destination(d_archive);
 {{- end}}
 
-
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_NX_OS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for CISCO_NX_OS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_NX_OS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-epoch-cisco_meraki.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-epoch-cisco_meraki.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "CISCO_MERAKI" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_cisco_meraki);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for CISCO_MERAKI traffic
+            source (s_CISCO_MERAKI);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_CISCO_MERAKI);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for CISCO_MERAKI traffic
+            source (s_DEFAULT);
+            filter(f_cisco_meraki);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("cisco_meraki", value("fields.sc4s_vendor_product"));
@@ -33,12 +39,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_TCP_PORT")) (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_CISCO_MERAKI_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for CISCO_MERAKI traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for CISCO_MERAKI traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-forcepoint_webprotect.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-forcepoint_webprotect.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "FORCEPOINT_WEBPROTECT" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_forcepoint_webprotect_kv);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_TCP_PORT")) (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for FORCEPOINT_WEBPROTECT traffic
+            source (s_FORCEPOINT_WEBPROTECT);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_FORCEPOINT_WEBPROTECT);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for FORCEPOINT_WEBPROTECT traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_forcepoint_webprotect_kv);
+            flags(final);
+        };
+    };
 
     rewrite {
         subst(" [^ =]+\=\-", "", value("MESSAGE"), flags("global"));
@@ -34,12 +40,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_TCP_PORT")) (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_FORCEPOINT_WEBPROTECT_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for FORCEPOINT_WEBPROTECT traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for FORCEPOINT_WEBPROTECT traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-fortinet_fortios.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-fortinet_fortios.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "FORTINET_FORTIOS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_fortinet_fortios);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for FORTINET_FORTIOS traffic
+            source (s_FORTINET_FORTIOS);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_FORTINET_FORTIOS);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for FORTINET_FORTIOS traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_fortinet_fortios);
+            flags(final);
+        };
+    };
 
     parser {
         kv-parser(prefix(".kv.") template("${MSGHDR} ${MSG}"));
@@ -53,12 +59,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_FORTINET_FORTIOS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for FORTINET_FORTIOS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for FORTINET_FORTIOS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-infoblox.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-infoblox.conf.tmpl
@@ -3,18 +3,23 @@
 {{- $context := dict "port_id" "INFOBLOX" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_infoblox);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_INFOBLOX_TCP_PORT")) (getenv  (print "SC4S_LISTEN_INFOBLOX_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_INFOBLOX_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for INFOBLOX traffic
+            source (s_INFOBLOX);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_INFOBLOX);
-{{- end}}
-
+        channel {
+        # Listen on the default port (typically 514) for INFOBLOX traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_infoblox);
+            flags(final);
+        };
+    };
 
     if {
         filter{program("named")};
@@ -67,12 +72,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_INFOBLOX_TCP_PORT")) (getenv  (print "SC4S_LISTEN_INFOBLOX_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_INFOBLOX_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for INFOBLOX traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for INFOBLOX traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-juniper_idp.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_idp.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "JUNIPER_IDP" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc5424_strict);
-    filter(f_juniper_idp);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_IDP traffic
+            source (s_JUNIPER_IDP);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_IDP);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_IDP traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc5424_strict);
+            filter(f_juniper_idp);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("juniper_idp", value("fields.sc4s_vendor_product"));
@@ -33,12 +39,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_IDP_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_IDP traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for JUNIPER_IDP traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "JUNIPER_JUNOS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_juniper_junos_standard);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_JUNOS traffic
+            source (s_JUNIPER_JUNOS);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_JUNOS);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_JUNOS traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_juniper_junos_standard);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("juniper_junos", value("fields.sc4s_vendor_product"));
@@ -52,12 +58,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_JUNOS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for JUNIPER_JUNOS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "JUNIPER_JUNOS_STRUCTURED" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc5424_strict);
-    filter(f_juniper_junos_structured);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_JUNOS_STRUCTURED traffic
+            source (s_JUNIPER_JUNOS_STRUCTURED);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_JUNOS_STRUCTURED);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_JUNOS_STRUCTURED traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc5424_strict);
+            filter(f_juniper_junos_structured);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("juniper_junos", value("fields.sc4s_vendor_product"));
@@ -60,12 +66,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_JUNOS_STRUCTURED_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_JUNOS_STRUCTURED traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for JUNIPER_JUNOS_STRUCTURED traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-juniper_netscreen.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_netscreen.conf.tmpl
@@ -5,17 +5,19 @@
 
 log {
     junction {
-	    channel {
-            source (s_DEFAULT);
-            filter(f_juniper_netscreen);
-            flags(final);
-        };
 {{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TLS_PORT")) }}
-	    channel {
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_NETSCREEN traffic
             source (s_JUNIPER_NETSCREEN);
             flags (final);
 	    };
 {{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_NETSCREEN traffic
+            source (s_DEFAULT);
+            filter(f_juniper_netscreen);
+            flags(final);
+        };
     };
 
     rewrite {

--- a/package/etc/conf.d/log_paths/lp-juniper_nsm.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_nsm.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "JUNIPER_NSM" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_juniper_nsm);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_NSM traffic
+            source (s_JUNIPER_NSM);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_NSM);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_NSM traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_juniper_nsm);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("juniper_nsm", value("fields.sc4s_vendor_product"));
@@ -33,12 +39,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_NSM traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for JUNIPER_NSM traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-juniper_nsm_idp.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_nsm_idp.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "JUNIPER_NSM_IDP" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_juniper_nsm_idp);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for JUNIPER_NSM_IDP traffic
+            source (s_JUNIPER_NSM_IDP);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_NSM_IDP);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for JUNIPER_NSM_IDP traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_juniper_nsm_idp);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("juniper_nsm_idp", value("fields.sc4s_vendor_product"));
@@ -32,12 +38,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NSM_IDP_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_NSM_IDP traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for JUNIPER_NSM_IDP traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-microfocus_arcsight.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-microfocus_arcsight.conf.tmpl
@@ -33,17 +33,24 @@ parser p_microfocus_arcsight_source {
         default-selector("unknown")
     );
 };
-{{- /* The following is an inline template to generate the actual log path */}}
-{{ define "log_path" }}
+
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_microfocus_arcsight);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_TCP_PORT")) (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for MICROFOCUS_ARCSIGHT traffic
+            source (s_MICROFOCUS_ARCSIGHT);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_MICROFOCUS_ARCSIGHT);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for MICROFOCUS_ARCSIGHT traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_microfocus_arcsight);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("microfocus_arcsight", value("fields.sc4s_vendor_product"));
@@ -82,14 +89,4 @@ log {
 {{- end}}
 
     flags(flow-control,final);
-
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_TCP_PORT")) (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_MICROFOCUS_ARCSIGHT_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for MICROFOCUS_ARCSIGHT traffic
-    {{tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for MICROFOCUS_ARCSIGHT traffic
-{{tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "PALOALTO_PANOS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_palalto_format);
-    filter(f_paloalto_panos);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for PALOALTO_PANOS traffic
+            source (s_PALOALTO_PANOS);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_PALOALTO_PANOS);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for PALOALTO_PANOS traffic
+            source (s_DEFAULT);
+            filter(f_is_palalto_format);
+            filter(f_paloalto_panos);
+            flags(final);
+        };
+    };
 
     # The palo message does not include a program value in the header, unfortunately.
     # The use of colon in the message tricks the RFC3164 parser; We will re-write the message
@@ -89,12 +95,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_PALOALTO_PANOS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for PALOALTO_PANOS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for PALOALTO_PANOS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-proofpoint_pps.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-proofpoint_pps.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "PROOFPOINT_PPS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter { filter(f_proofpoint_pps_filter) or filter(f_proofpoint_pps_sendmail) };
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_PROOFPOINT_PPS);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for PROOFPOINT_PPS traffic
+            source (s_PROOFPOINT_PPS);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for PROOFPOINT_PPS traffic
+            source (s_DEFAULT);
+            filter { filter(f_proofpoint_pps_filter) or filter(f_proofpoint_pps_sendmail) };
+            flags(final);
+        };
+    };
 
     if (filter(f_proofpoint_pps_filter)) {
         rewrite {
@@ -40,12 +46,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_PROOFPOINT_PPS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for PROOFPOINT_PPS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for PROOFPOINT_PPS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-sc4s_internal.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-sc4s_internal.conf.tmpl
@@ -1,4 +1,3 @@
-{{- define "log_path"}}
 log {
     source(s_internal);
 
@@ -36,6 +35,4 @@ log {
 
     };
      flags(flow-control,final);
- };
-{{- end}}
-{{- tmpl.Exec "log_path" "yes" }}
+};

--- a/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
@@ -1,6 +1,5 @@
 # Startup events
 
-{{- define "log_path"}}
 log {
     source(s_startup_out);
 
@@ -32,6 +31,4 @@ log {
 {{- end}}
 
     flags(flow-control,final);
- };
-{{- end}}
-{{- tmpl.Exec "log_path" "yes" }}
+};

--- a/package/etc/conf.d/log_paths/lp-symantec_brightmail.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-symantec_brightmail.conf.tmpl
@@ -27,17 +27,23 @@ parser symantec_brightmail_grouping {
 {{- $context := dict "port_id" "SYMANTEC_BRIGHTMAIL" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_symantec_brightmail);
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_SYMANTEC_BRIGHTMAIL);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_SYMANTEC_BRIGHTMAIL_TCP_PORT")) (getenv  (print "SC4S_LISTEN_SYMANTEC_BRIGHTMAIL_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_SYMANTEC_BRIGHTMAIL_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for SYMANTEC_BRIGHTMAIL traffic
+            source (s_SYMANTEC_BRIGHTMAIL);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for SYMANTEC_BRIGHTMAIL traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_symantec_brightmail);
+            flags(final);
+        };
+    };
 
 {{- if (conv.ToBool (getenv "SC4S_SOURCE_FF_SYMANTEC_BRIGHTMAIL_GROUPMSG" "yes")) }}
     if {
@@ -89,12 +95,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_SYMANTEC_BRIGHTMAIL_TCP_PORT")) (getenv  (print "SC4S_LISTEN_SYMANTEC_BRIGHTMAIL_UDP_PORT"))) (getenv  (print "SC4S_SYMANTEC_BRIGHTMAIL_NSS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for SYMANTEC_BRIGHTMAIL traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for SYMANTEC_BRIGHTMAIL traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-symantec_proxy.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-symantec_proxy.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "SYMANTEC_PROXY" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc5424_noversion);
-    filter(f_symantec_bluecoat_proxy);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_TCP_PORT")) (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for SYMANTEC_PROXY traffic
+            source (s_SYMANTEC_PROXY);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_SYMANTEC_PROXY);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for SYMANTEC_PROXY traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc5424_noversion);
+            filter(f_symantec_bluecoat_proxy);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("bluecoat_proxy", value("fields.sc4s_vendor_product"));
@@ -34,12 +40,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_TCP_PORT")) (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_SYMANTEC_PROXY_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for SYMANTEC_PROXY traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for SYMANTEC_PROXY traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-ubiquiti_unifi.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-ubiquiti_unifi.conf.tmpl
@@ -3,17 +3,23 @@
 {{- $context := dict "port_id" "UBIQUITI_UNIFI" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_ubiquiti_unifi);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_TCP_PORT")) (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for UBIQUITI_UNIFI traffic
+            source (s_UBIQUITI_UNIFI);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_UBIQUITI_UNIFI);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for UBIQUITI_UNIFI traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_ubiquiti_unifi);
+            flags(final);
+        };
+    };
 
     parser {p_add_context_splunk(key("ubiquiti_unifi")); };
 
@@ -119,14 +125,4 @@ log {
 {{- end}}
 
     flags(flow-control,final);
-
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_TCP_PORT")) (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_UBIQUITI_UNIFI_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for UBIQUITI_UNIFI traffic
-{{tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for UBIQUITI_UNIFI traffic
-{{tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-vmware_vsphere.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-vmware_vsphere.conf.tmpl
@@ -1,18 +1,24 @@
 # VMware ESXi and NSX
 {{- /* The following provides a unique port source configuration if env var(s) are set */}}
-{{- $context := dict "port_id" "VMWARE" "parser" "common" }}
+{{- $context := dict "port_id" "VMWARE_VSPHERE" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_vmware_all);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_VMWARE_VSPHERE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_VMWARE_VSPHERE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_VMWARE_VSPHERE_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for VMWARE_VSPHERE traffic
+            source (s_VMWARE_VSPHERE);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_VMWARE);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for VMWARE_VSPHERE traffic
+            source (s_DEFAULT);
+            filter(f_vmware_all);
+            flags(final);
+        };
+    };
 
     #NSX first because its the cheapest check
     if {
@@ -83,21 +89,13 @@ log {
         rewrite { set("$(template ${.splunk.sc4s_template} $(template t_legacy_hdr_msg))" value("MSG")); };
     };
 
-{{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_VMWARE_HEC" "no")) }}
+{{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_VMWARE_VSPHERE_HEC" "no")) }}
     destination(d_hec);
 {{- end}}
 
-{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_VMWARE" "no")) }}
+{{- if or (conv.ToBool (getenv "SC4S_ARCHIVE_GLOBAL" "no")) (conv.ToBool (getenv "SC4S_ARCHIVE_VMWARE_VSPHERE" "no")) }}
     destination(d_archive);
 {{- end}}
 
     flags(flow-control,final);
 };
-{{- end}}
-{{- if or (or (getenv  (print "SC4S_LISTEN_VMWARE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_VMWARE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_VMWARE_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for VMWARE traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for VMWARE traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-zscaler_nss.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zscaler_nss.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "ZSCALER_NSS" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter(f_zscaler_nss);
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_ZSCALER_NSS);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for ZSCALER_NSS traffic
+            source (s_ZSCALER_NSS);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for ZSCALER_NSS traffic
+            source (s_DEFAULT);
+            filter(f_zscaler_nss);
+            flags(final);
+        };
+    };
 
     parser { date-parser(format("%Y-%m-%d %H:%M:%S") template('$(substr "$LEGACY_MSGHDR$MSG" "0" "19")')); };
     rewrite {
@@ -74,12 +80,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_TCP_PORT")) (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_ZSCALER_NSS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for ZSCALER_NSS traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for ZSCALER_NSS traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-zzy-nix_syslog.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zzy-nix_syslog.conf.tmpl
@@ -3,16 +3,22 @@
 {{- $context := dict "port_id" "NIX_SYSLOG" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes" }}
-    source(s_DEFAULT);
-    filter(f_nix_syslog);
-{{- end }}
-{{- if eq (.) "no" }}
-    source (s_NIX_SYSLOG);
-{{- end }}
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_NIX_SYSLOG_TCP_PORT")) (getenv  (print "SC4S_LISTEN_NIX_SYSLOG_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_NIX_SYSLOG_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for NIX_SYSLOG traffic
+            source (s_NIX_SYSLOG);
+            flags (final);
+	    };
+{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for NIX_SYSLOG traffic
+            source (s_DEFAULT);
+            filter(f_nix_syslog);
+            flags(final);
+        };
+    };
 
     rewrite {
         set("nix_syslog", value("fields.sc4s_vendor_product"));
@@ -36,12 +42,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_NIX_SYSLOG_TCP_PORT")) (getenv  (print "SC4S_LISTEN_NIX_SYSLOG_UDP_PORT"))) (getenv  (print "SC4S_NIX_SYSLOG_NSS_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for NIX_SYSLOG traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end}}
-
-# Listen on the default port (typically 514) for NIX_SYSLOG traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/conf.d/log_paths/lp-zzz-fallback.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zzz-fallback.conf.tmpl
@@ -29,5 +29,4 @@ log {
 {{- end}}
 
     flags(flow-control,fallback);
-
 };

--- a/package/etc/conf.d/log_paths/p_rfc3164-juniper_netscreen.conf.tmpl
+++ b/package/etc/conf.d/log_paths/p_rfc3164-juniper_netscreen.conf.tmpl
@@ -3,16 +3,20 @@
 {{- $context := dict "port_id" "JUNIPER_NETSCREEN" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_juniper_netscreen);
+    junction {
+	    channel {
+            source (s_DEFAULT);
+            filter(f_juniper_netscreen);
+            flags(final);
+        };
+{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TLS_PORT")) }}
+	    channel {
+            source (s_JUNIPER_NETSCREEN);
+            flags (final);
+	    };
 {{- end}}
-{{- if eq (.) "no"}}
-    source (s_JUNIPER_NETSCREEN);
-{{- end}}
+    };
 
     rewrite {
         set("juniper_netscreen", value("fields.sc4s_vendor_product"));
@@ -32,12 +36,3 @@ log {
 
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TCP_PORT")) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_JUNIPER_NETSCREEN_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for JUNIPER_NETSCREEN traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end }}
-
-# Listen on the default port (typically 514) for JUNIPER_NETSCREEN traffic
-{{ tmpl.Exec "log_path" "yes" }}

--- a/package/etc/local_config/log_paths/lp-example.conf.tmpl
+++ b/package/etc/local_config/log_paths/lp-example.conf.tmpl
@@ -29,24 +29,23 @@
 {{- $context := dict "port_id" "LOCAL_EXAMPLE" "parser" "common" }}
 {{- tmpl.Exec "t/source_network.t" $context }}
 
-{{- /* The following is an inline template to generate the actual log path */}}
-{{- define "log_path"}}
 log {
-
-{{- /* The first time this template is used the log_path will be linked to the default port */}}
-
-{{- if eq (.) "yes"}}
-    source(s_DEFAULT);
-    filter(f_is_rfc3164);
-    filter(f_local_example);
+    junction {
+{{- if or (or (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TLS_PORT")) }}
+        channel {
+        # Listen on the specified dedicated port(s) for LOCAL_EXAMPLE traffic
+            source (s_LOCAL_EXAMPLE);
+            flags (final);
+	    };
 {{- end}}
-
-{{- /* In the second pass through the template a link to the dedicated port is used. This */}}
-{{- /* normally does not require additional filters */}}
-
-{{- if eq (.) "no"}}
-    source (s_LOCAL_EXAMPLE);
-{{- end}}
+        channel {
+        # Listen on the default port (typically 514) for LOCAL_EXAMPLE traffic
+            source (s_DEFAULT);
+            filter(f_is_rfc3164);
+            filter(f_local_example);
+            flags(final);
+        };
+    };
 
 # Set a default sourcetype and index, as well as an appropriate value for the field
 # "sc4s_vendor_product".  This field is sent as an indexed field to Splunk,
@@ -87,15 +86,3 @@ log {
 # All passes through any matching log path will be final
     flags(flow-control,final);
 };
-{{- end}}
-
-{{- /* Prepare to run two passes through this template, one for default traffic and another for */}}
-{{- /* "unique ports" if they are configured. */}}
-
-{{- if or (or (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TCP_PORT")) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_UDP_PORT"))) (getenv  (print "SC4S_LISTEN_LOCAL_EXAMPLE_TLS_PORT")) }}
-# Listen on the specified dedicated port(s) for LOCAL_EXAMPLE traffic
-{{ tmpl.Exec "log_path" "no" }}
-{{- end }}
-
-# Listen on the default port (typically 514) for LOCAL_EXAMPLE traffic
-{{ tmpl.Exec "log_path" "yes" }}


### PR DESCRIPTION
* Remove message formatting prefix from log path names
* Apply `lp-` prefix to indicate config file is a log path
* Rename certain log paths to be more descriptive of function
* Replace two-pass gomplate config with junction/channel config in each log path