### PR TITLE
Add guess-timezone() to sources with epoch timestamps

### DIFF
--- a/package/etc/conf.d/filters/cisco/meraki.conf
+++ b/package/etc/conf.d/filters/cisco/meraki.conf
@@ -15,7 +15,9 @@ parser p_cisco_meraki {
         };
         parser {
             date-parser(format('%s')
-                        template("${EPOCH}"));
+                        template("${EPOCH}")
+                        flags(guess-timezone)
+            );
         };
     };
 

--- a/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
@@ -16,11 +16,15 @@ parser p_cef_header {
 };
 
 parser p_cef_ts_rt {
-    date-parser(format("%s") template("${.cef.rt}")
+    date-parser(format('%s')
+                template("${.cef.rt}")
+                flags(guess-timezone)
     );
 };
 parser p_cef_ts_end {
-    date-parser(format("%s") template("${.cef.end}")
+    date-parser(format('%s')
+                template("${.cef.end}")
+                flags(guess-timezone)    
     );
 };
 


### PR DESCRIPTION
* Add the guess-timezone() flag to log paths that parse epoch timestamps.  Though epoch is timezone-free, it can be set incorrectly by the sending device and/or test tools.