### PR TITLE
Update docker port range to 5000-5007

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def sc4s_docker(docker_services):
     docker_services.start('sc4s')
 
     ports = {514:  docker_services.port_for("sc4s", 514)}
-    for x in range(5000, 5006):
+    for x in range(5000, 5007):
         ports.update({x: docker_services.port_for("sc4s", x)})
 
     return docker_services.docker_ip, ports


### PR DESCRIPTION
* Update docker-compose port range from 5000-5006 to 5000-5007 to account for pfsense tests on port 5006.  Will get a "key error" if range stops at 5006.