### PR TITLE
Startup log path `splunk_indexes.conf` fix

### DIFF
--- a/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
@@ -3,8 +3,8 @@
 log {
     source(s_startup_out);
 
-    rewrite { r_set_splunk_dest_default(sourcetype("sc4s:events"), index("main"))};
-    parser {p_add_context_splunk(key("sc4s_events:startup:out")); };
+    rewrite { r_set_splunk_dest_default(sourcetype("sc4s_events:startup:out"), index("main"))};
+    parser {p_add_context_splunk(key("sc4s:events")); };
 
     {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_INTERNAL_EVENTS_HEC" "no")) }}
     destination(d_hec_internal);


### PR DESCRIPTION
* Fix sourcetype/key reversal in startup log path