### PR TITLE
Correct vendor_product key for syslog-ng std output

### DIFF
--- a/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-sc4s_startup.conf.tmpl
@@ -4,7 +4,7 @@ log {
     source(s_startup_out);
 
     rewrite { r_set_splunk_dest_default(sourcetype("sc4s_events:startup:out"), index("main"))};
-    parser {p_add_context_splunk(key("sc4s:events")); };
+    parser {p_add_context_splunk(key("sc4s_events")); };
 
     {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_INTERNAL_EVENTS_HEC" "no")) }}
     destination(d_hec_internal);


### PR DESCRIPTION
When a non-main index was selected for sc4s:events this subtype was not routed due to a typo