### PR TITLE
Update internal log batch timeout

### DIFF
--- a/package/etc/conf.d/destinations/splunk_hec_internal.conf.tmpl
+++ b/package/etc/conf.d/destinations/splunk_hec_internal.conf.tmpl
@@ -6,7 +6,7 @@ destination d_hec_internal {
          workers(10)
          batch-lines({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_LINES" "1000"}})
          batch-bytes({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_BYTES" "4096kb"}})
-         batch-timeout({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_TIMEOUT" "1"}})
+         batch-timeout({{- getenv "SC4S_DEST_SPLUNK_HEC_BATCH_TIMEOUT" "1000"}})
          timeout({{- getenv "SC4S_DEST_SPLUNK_HEC_TIMEOUT" "30"}})
          user_agent("sc4s/1.0 (events)")
          user("sc4s")


### PR DESCRIPTION
* Update batch timeout on the `d_hec_internal` destination from 1ms to 1000ms to more closely align to the regular `d_hec` destination