### PR TITLE
Changed sourcetype of RT_IDS events of Juniper to juniper:junos:firewall

### DIFF
--- a/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
@@ -32,7 +32,7 @@ log {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netfw"))};
         parser {p_add_context_splunk(key("juniper_junos_fw")); };
     } elif (program('RT_IDS')) {
-        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:idp"), index("netids"))};
+        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netfw"))};
         parser {p_add_context_splunk(key("juniper_junos_ids")); };
     } elif (program('RT_UTM')) {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netids"))};

--- a/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
@@ -31,7 +31,7 @@ log {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };
         parser {p_add_context_splunk(key("juniper_junos_fw_structured")); };
     } elif (program('RT_IDS')) {
-        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:idp:structured"), index("netids")) };
+        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };
         parser {p_add_context_splunk(key("juniper_junos_ids_structured")); };
     } elif (program('RT_UTM')) {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };

--- a/tests/test_juniper_junos_rfc3164.py
+++ b/tests/test_juniper_junos_rfc3164.py
@@ -61,7 +61,7 @@ def test_juniper_idp_standard(record_property, setup_wordlist, get_host_key, set
 
     sendsingle(message)
 
-    st = env.from_string("search index=netids host=\"{{ host }}\" sourcetype=\"juniper:junos:idp\" | head 2")
+    st = env.from_string("search index=netfw host=\"{{ host }}\" sourcetype=\"juniper:junos:idp\" | head 2")
     search = st.render(host=host)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)

--- a/tests/test_juniper_junos_rfc5124.py
+++ b/tests/test_juniper_junos_rfc5124.py
@@ -44,7 +44,7 @@ def test_juniper_junos_idp_structured(record_property, setup_wordlist, get_host_
 
     sendsingle(message)
 
-    st = env.from_string("search index=netids host=\"{{ host }}\" sourcetype=\"juniper:junos:idp:structured\" | head 2")
+    st = env.from_string("search index=netfw host=\"{{ host }}\" sourcetype=\"juniper:junos:idp:structured\" | head 2")
     search = st.render(host=host)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)


### PR DESCRIPTION
* Currently add-on is indexing the RT_IDS events to juniper:junos:firewall sourcetype and SC4S is indexing the same events to juniper:junos:idp sourcetype. Hence, modified the sourcetype for **RT_IDS** events to make it consistent with the add-on.