### PR TITLE
Changed sourcetype of RT_IDS events of Juniper to juniper:junos:firewall

### DIFF
--- a/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos.conf.tmpl
@@ -32,7 +32,7 @@ log {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netfw"))};
         parser {p_add_context_splunk(key("juniper_junos_fw")); };
     } elif (program('RT_IDS')) {
-        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:idp"), index("netids"))};
+        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netfw"))};
         parser {p_add_context_splunk(key("juniper_junos_ids")); };
     } elif (program('RT_UTM')) {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall"), index("netids"))};

--- a/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-juniper_junos_structured.conf.tmpl
@@ -31,7 +31,7 @@ log {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };
         parser {p_add_context_splunk(key("juniper_junos_fw_structured")); };
     } elif (program('RT_IDS')) {
-        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:idp:structured"), index("netids")) };
+        rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };
         parser {p_add_context_splunk(key("juniper_junos_ids_structured")); };
     } elif (program('RT_UTM')) {
         rewrite { r_set_splunk_dest_default(sourcetype("juniper:junos:firewall:structured"), index("netfw")) };


### PR DESCRIPTION
* Currently, the Juniper add-on is indexing the RT_IDS events to juniper:junos:firewall sourcetype and SC4S is indexing the same events to juniper:junos:idp sourcetype. Hence, modified the sourcetype for RT_IDS events to make it consistent with the add-on.