### PR TITLE
Add non-filtering date-parser() option

### DIFF
--- a/package/etc/conf.d/conflib/_common/date-parser_nofilter.conf.tmpl
+++ b/package/etc/conf.d/conflib/_common/date-parser_nofilter.conf.tmpl
@@ -1,0 +1,16 @@
+block parser date-parser-nofilter(
+    format()
+    template()
+    ) {
+        channel {
+            if {
+                parser {
+                    date-parser(format(`format`) template("`template`")
+                    time-zone({{- getenv "SC4S_DEFAULT_TIMEZONE" "GMT"}})
+                    flags(guess-timezone));
+                };
+            } else {
+                rewrite { set("date/time parser failed; possible rogue message. Expected strptime format: `format`; Actual timestamp: `template`" value("fields.sc4s_error")); };
+            };
+        };
+    };

--- a/package/etc/conf.d/filters/cisco/cisco_syslog.conf
+++ b/package/etc/conf.d/filters/cisco/cisco_syslog.conf
@@ -11,32 +11,20 @@ filter f_is_cisco_syslog{
 parser cisco-parser-ex{
     channel {
         filter {
-            #message('^<\d*> ?(?:(\d+)\: )?(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]): )?(?:(\d+): )?(?:(\d\d:\d\d:\d\d|\d{1,6} \d{1,2}))?(?:(\*)?((?:\w\w\w {1,2}\d{1,2} (?:\d{2,4} )?\d\d:\d\d:\d\d)(?:\.\d{3,6})?( [AP]M)?)( [A-Z]{3,3})?)?( \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} )?: ((\%[^\: ]+)\:? ?.*)' flags(store-matches));
+    #            #message('^<\d*> ?(?:(\d+)\: )?(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]): )?(?:(\d+): )?(?:(\d\d:\d\d:\d\d|\d{1,6} \d{1,2}))?(?:(\*)?((?:\w\w\w {1,2}\d{1,2} (?:\d{2,4} )?\d\d:\d\d:\d\d)(?:\.\d{3,6})?( [AP]M)?)( [A-Z]{3,3})?)?( \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3} )?: ((\%[^\: ]+)\:? ?.*)' flags(store-matches));
             message('^^<\d*> ?(?:(\d+)\: )?(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]): )?(?:(\d+): )?(?:(\d\d:\d\d:\d\d|\d{1,6} \d{1,2}))?(?:(\*)?((?:\w\w\w {1,2}\d{1,2} (?:\d{2,4} )?\d\d:\d\d:\d\d)(?:\.\d{3,6})?( [AP]M)?)( [A-Z]{3,3})?)? ?(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]))? ?: ((\%[^\: ]+)\:? ?.*)' flags(store-matches));
-        };        
-        if {
-            #Mar  4 11:45:20
-            #Apr 29 13:58:46.000001
-            #Apr 29 13:58:46.411
-            #Mar  1 18:48:50.483 UTC NOTE: Reverse TZ "%Z" parsing will not work for non-local timezones.
-            # guess-timezone() will be used to reconcile timezones
-            parser {
-                    date-parser(format(
-                                    '%b %d %H:%M:%S.%f',
-                                    '%b %d %H:%M:%S',
-                                    '%b %d %I:%M:%S %p.%f',
-                                    '%b %d %I:%M:%S %p',
-                                    '%b %d %Y %H:%M:%S.%f'
-                                    '%b %d %Y %H:%M:%S',
-                                    )
-                template("$8")
-                flags(guess-timezone)
-                );
-            };
-        } else {
-#           rewrite { set("date/time parser failed", value("fields.sc4s_error")); };
-            rewrite { set("date/time parser failed on string $8" value("fields.sc4s_error")); };
         };
+
+        parser { date-parser-nofilter(format(
+             '%b %d %H:%M:%S.%f',
+             '%b %d %H:%M:%S',
+             '%b %d %I:%M:%S %p.%f',
+             '%b %d %I:%M:%S %p',
+             '%b %d %Y %H:%M:%S.%f',
+             '%b %d %Y %H:%M:%S')
+             template("$8"));
+        };
+
         rewrite {
             set(
                 "${4}",
@@ -57,6 +45,5 @@ parser cisco-parser-ex{
                 value("MESSAGE")                
             );
         };
-
     };
 };

--- a/package/etc/conf.d/filters/cisco/meraki.conf
+++ b/package/etc/conf.d/filters/cisco/meraki.conf
@@ -14,9 +14,8 @@ parser p_cisco_meraki {
             );
         };
         parser {
-            date-parser(format('%s.%f')
+            date-parser-nofilter(format('%s.%f')
                         template("${EPOCH}.${TIMESECFRAC}")
-                        flags(guess-timezone)
             );
         };
     };

--- a/package/etc/conf.d/filters/cisco/ucm.conf
+++ b/package/etc/conf.d/filters/cisco/ucm.conf
@@ -15,23 +15,11 @@ filter f_cisco_ucm_message {
 };
 
 parser p_cisco_ucm_date {
-    channel {
-        #Oct 14 2015 05:50:19 AM.484 (timezone skipped; '%Z' date-parser only works for local TZ)
-        #Apr 21 19:01:35.638 (timezone skipped; '%Z' date-parser only works for local TZ)
-        if {
-            parser {
-                date-parser(format(
+                date-parser-nofilter(format(
                     '%b %d %H:%M:%S.%f',
                     '%b %d %Y %I:%M:%S %p.%f'
                     )
-                    template("$3")
-                    flags(guess-timezone)
-                );
-            };
-        } else {
-            rewrite { set("date/time parser failed on string $3" value("fields.sc4s_error")); };
-        };
-    };
+                    template("$3"));
 };
 
 rewrite r_cisco_ucm_message {

--- a/package/etc/conf.d/filters/citrix/netscaler.conf.tmpl
+++ b/package/etc/conf.d/filters/citrix/netscaler.conf.tmpl
@@ -11,14 +11,12 @@ filter f_citrix_netscaler_message {
 parser p_citrix_netscaler_date {
 {{- if (conv.ToBool (getenv "SC4S_SOURCE_CITRIX_NETSCALER_USEALT_DATE_FORMAT" "no")) }}
     #10/01/2001:01:01:01 GMT
-    date-parser(format("%m/%d/%Y:%H:%M:%S")
-                template("$2")
-                flags(guess-timezone));
+    date-parser-nofilter(format('%m/%d/%Y:%H:%M:%S')
+                template("$2"));
 {{- else }}
     #01/10/2001:01:01:01 GMT
-    date-parser(format("%d/%m/%Y:%H:%M:%S")
-                template("$2")
-                flags(guess-timezone));
+    date-parser-nofilter(format('%d/%m/%Y:%H:%M:%S')
+                template("$2"));
 {{- end }}
 };
 

--- a/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
@@ -35,46 +35,46 @@ log {
     } else {
         parser {
             kv-parser(prefix(".kv.") pair-separator("|") template("${MSGHDR} ${MSG}"));
-            date-parser(format("%s") template("${.kv.time}") time-zone({{- getenv "SC4S_DEFAULT_TIMEZONE" "GMT"}}) flags(guess-timezone));
+            date-parser-nofilter(format("%s") template("${.kv.time}"));
         };
+    };
 
-        rewrite {
-            set("${.kv.hostname}", value("HOST"));
-            set("checkpoint_splunk", value("fields.sc4s_vendor_product"));
-            r_set_splunk_dest_default(sourcetype("cp_log"), index("netops"))
-        };
+    rewrite {
+        set("${.kv.hostname}", value("HOST"));
+        set("checkpoint_splunk", value("fields.sc4s_vendor_product"));
+        r_set_splunk_dest_default(sourcetype("cp_log"), index("netops"))
+    };
 
-        parser {p_add_context_splunk(key("checkpoint_splunk")); };
+    parser {p_add_context_splunk(key("checkpoint_splunk")); };
 
-        if  {
-           filter(f_checkpoint_splunk_NetworkTraffic);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("firewall"), index("netfw"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_firewall")); };
-        } elif  {
-           filter(f_checkpoint_splunk_Web);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("web"), index("netproxy"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_web")); };
-        } elif  {
-           filter(f_checkpoint_splunk_NetworkSessions);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("sessions"), index("netops"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_sessions")); };
-        } elif  {
-           filter(f_checkpoint_splunk_IDS_Malware);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("ids_malware"), index("netids"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_ids")); };
-        } elif  {
-           filter(f_checkpoint_splunk_IDS);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("ids"), index("netids"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_ids")); };
-        } elif  {
-           filter(f_checkpoint_splunk_email);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("email"), index("email"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_email")); };
-        } elif  {
-           filter(f_checkpoint_splunk_DLP);
-           rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("firewall"), index("netdlp"))};
-           parser {p_add_context_splunk(key("checkpoint_splunk_dlp")); };
-        };
+    if  {
+       filter(f_checkpoint_splunk_NetworkTraffic);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("firewall"), index("netfw"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_firewall")); };
+    } elif  {
+       filter(f_checkpoint_splunk_Web);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("web"), index("netproxy"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_web")); };
+    } elif  {
+       filter(f_checkpoint_splunk_NetworkSessions);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("sessions"), index("netops"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_sessions")); };
+    } elif  {
+       filter(f_checkpoint_splunk_IDS_Malware);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("ids_malware"), index("netids"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_ids")); };
+    } elif  {
+       filter(f_checkpoint_splunk_IDS);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("ids"), index("netids"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_ids")); };
+    } elif  {
+       filter(f_checkpoint_splunk_email);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("email"), index("email"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_email")); };
+    } elif  {
+       filter(f_checkpoint_splunk_DLP);
+       rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("firewall"), index("netdlp"))};
+       parser {p_add_context_splunk(key("checkpoint_splunk_dlp")); };
     };
 
     parser (compliance_meta_by_source);

--- a/package/etc/conf.d/log_paths/lp-cisco_acs.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_acs.conf.tmpl
@@ -47,9 +47,9 @@ parser acs_event_time {
         flags(greedy)
     );
 
-    date-parser(
+    date-parser-nofilter(
             #YYYY- MM-DD hh:mm:ss:xxx +/-zh:zm
-            format("%Y-%m-%d %H:%M:%S.%f %z" )
+            format('%Y-%m-%d %H:%M:%S.%f %z')
             template("${ACS.DATE} ${ACS.TIME} ${ACS.TZ}")
     );
 };

--- a/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
@@ -47,9 +47,9 @@ parser ise_event_time {
         flags(greedy)
     );
 
-    date-parser(
+    date-parser-nofilter(
             #YYYY- MM-DD hh:mm:ss:xxx +/-zh:zm
-            format("%Y-%m-%d %H:%M:%S.%f %z" )
+            format('%Y-%m-%d %H:%M:%S.%f %z')
             template("${ISE.DATE} ${ISE.TIME} ${ISE.TZ}")
     );
 };

--- a/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
@@ -16,15 +16,13 @@ parser p_cef_header {
 };
 
 parser p_cef_ts_rt {
-    date-parser(format('%s')
+    date-parser-nofilter(format('%s')
                 template("${.cef.rt}")
-                flags(guess-timezone)
     );
 };
 parser p_cef_ts_end {
-    date-parser(format('%s')
+    date-parser-nofilter(format('%s')
                 template("${.cef.end}")
-                flags(guess-timezone)    
     );
 };
 

--- a/package/etc/conf.d/log_paths/lp-fortinet.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-fortinet.conf.tmpl
@@ -33,28 +33,24 @@ log {
             subst('([\+-])(\d)(?=:)(:\d+)', "${1}0${2}${3}", value(".kv.timezone"));
         };
         parser {
-            date-parser(
-                format("%Y-%m-%d:%H:%M:%S%z")
-                template('${.kv.date}:${.kv.time}${.kv.timezone}')
-                flags(guess-timezone)
+            date-parser-nofilter(
+                format('%Y-%m-%d:%H:%M:%S%z')
+                template("${.kv.date}:${.kv.time}${.kv.timezone}")
             );
         };
     } elif {
         filter { match('.{5}' value (".kv.tz")) };
         parser {
-            date-parser(
-                format("%Y-%m-%d:%H:%M:%S%z")
+            date-parser-nofilter(
+                format('%Y-%m-%d:%H:%M:%S%z')
                 template("${.kv.date}:${.kv.time}${.kv.tz}")
-                flags(guess-timezone)
             );
         };
     } elif {
         parser {
-            date-parser(
-                format("%Y-%m-%d:%H:%M:%S")
+            date-parser-nofilter(
+                format('%Y-%m-%d:%H:%M:%S')
                 template("${.kv.date}:${.kv.time}")
-                time-zone({{- getenv "SC4S_DEFAULT_TIMEZONE" "GMT"}})
-                flags(guess-timezone)
             );
         };
     } else {

--- a/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
@@ -41,13 +41,10 @@ log {
             );
         #2012/04/10 04:39:55
         #parse the date
-        date-parser(format(
+        date-parser-nofilter(format(
                 '%Y/%m/%d %H:%M:%S.%f',
-                '%Y/%m/%d %H:%M:%S'
-                )
+                '%Y/%m/%d %H:%M:%S')
                 template("${.pan.generated_time}")
-                time-zone({{- getenv "SC4S_DEFAULT_TIMEZONE" "GMT"}})
-                flags(guess-timezone)
         );
     };
 

--- a/package/etc/conf.d/log_paths/lp-zscaler_lss.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zscaler_lss.conf.tmpl
@@ -22,14 +22,11 @@ log {
     };
     parser {
         #.jsonLog.Timestamp Mar 04 20:37:53 2020
-                date-parser(
-                format("%a %b %d %H:%M:%S %Y",
-                       "%a %b %d %k:%M:%S %Y")
-                template("${.json.LogTimestamp}")
-                time-zone({{- getenv "SC4S_DEFAULT_TIMEZONE" "GMT"}})
-                flags(guess-timezone)
-        );
-
+        date-parser-nofilter(
+        format('%a %b %d %H:%M:%S %Y',
+               '%a %b %d %k:%M:%S %Y')
+               template("${.json.LogTimestamp}")
+               );
     };
     if {
         filter {

--- a/package/etc/conf.d/log_paths/lp-zscaler_nss.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zscaler_nss.conf.tmpl
@@ -26,7 +26,7 @@ log {
         parser (compliance_meta_by_source);
         rewrite { set("$(template ${.splunk.sc4s_template} $(template t_msg_only))" value("MSG")); };
     } else {
-        parser { date-parser(format("%Y-%m-%d %H:%M:%S") template('$(substr "$LEGACY_MSGHDR$MSG" "0" "19")') flags(guess-timezone)); };
+        parser { date-parser-nofilter(format("%Y-%m-%d %H:%M:%S") template('$(substr "$LEGACY_MSGHDR$MSG" "0" "19")')); };
         rewrite {
             set("zscaler_nss", value("fields.sc4s_vendor_product"));
             subst("^[^\t]+\t", "", value("MESSAGE"), flags("global"));

--- a/tests/test_cisco_acs.py
+++ b/tests/test_cisco_acs.py
@@ -59,12 +59,12 @@ def test_cisco_acs_multi(record_property, setup_wordlist, setup_splunk, setup_sc
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     # Generate new datetime for second message; not used in log path parser so actually could be anything
-    dt = datetime.datetime.now()
-    second_bsd = dt.strftime("%b %d %H:%M:%S")
+    dt = datetime.datetime.now() + datetime.timedelta(seconds=1)
+    bsd = dt.strftime("%b %d %H:%M:%S")
 
     mt = env.from_string(
-        "{{ mark }} {{ second_bsd }} {{ host }} CSCOacs_Passed_Authentications 0000000002 2 1 Step=13015 , SelectedAuthenticationIdentityStores=Internal Users, NetworkDeviceGroups=s1Migrated_NDGs:All s1Migrated_NDGs, NetworkDeviceGroups=Device Type:All Device Types, NetworkDeviceGroups=Location:All Locations, ServiceSelectionMatchedRule=Rule-2, IdentityPolicyMatchedRule=Default, AuthorizationPolicyMatchedRule=Rule-0, Action=Login, Privilege-Level=1, Authen-Type=ASCII, Service=Login, Remote-Address=10.78.167.190, UserIdentityGroup=IdentityGroup:All\n")
-    message = mt.render(mark="<165>", second_bsd=second_bsd, bsd=bsd, host=host, date=date, time=time, tzoffset=tzoffset)
+        "{{ mark }} {{ bsd }} {{ host }} CSCOacs_Passed_Authentications 0000000002 2 1 Step=13015 , SelectedAuthenticationIdentityStores=Internal Users, NetworkDeviceGroups=s1Migrated_NDGs:All s1Migrated_NDGs, NetworkDeviceGroups=Device Type:All Device Types, NetworkDeviceGroups=Location:All Locations, ServiceSelectionMatchedRule=Rule-2, IdentityPolicyMatchedRule=Default, AuthorizationPolicyMatchedRule=Rule-0, Action=Login, Privilege-Level=1, Authen-Type=ASCII, Service=Login, Remote-Address=10.78.167.190, UserIdentityGroup=IdentityGroup:All\n")
+    message = mt.render(mark="<165>", bsd=bsd, host=host, date=date, time=time, tzoffset=tzoffset)
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string("search _time={{ epoch }} index=netauth host=\"{{ host }}\" sourcetype=\"cisco:acs\" \"Step=13015\"")

--- a/tests/test_cisco_ise.py
+++ b/tests/test_cisco_ise.py
@@ -24,7 +24,7 @@ def test_cisco_ise_multi(record_property, setup_wordlist, setup_splunk, setup_sc
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
 
-    # Tune time functions for Cisco ACS
+    # Tune time functions for Cisco ISE
     time = time[:-3]
     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
     epoch = epoch[:-3]
@@ -33,6 +33,10 @@ def test_cisco_ise_multi(record_property, setup_wordlist, setup_splunk, setup_sc
         "{{ mark }} {{ bsd }} {{ host }} CISE_Passed_Authentications 0001939187 4 0 {{ date }} {{ time }} {{ tzoffset }} 0042009748 5200 NOTICE Passed-Authentication: Authentication succeeded, ConfigVersionId=128, Device IP Address=10.6.64.15, DestinationIPAddress=10.16.20.23, DestinationPort=1812, UserName=90-1B-0E-34-EA-92, Protocol=Radius, RequestLatency=8, NetworkDeviceName=ICPAV2-SW15, User-Name=901b0e34ea92, NAS-IP-Address=10.6.64.15, NAS-Port=50104, Service-Type=Call Check, Framed-IP-Address=10.6.226.138, Framed-MTU=1500, Called-Station-ID=B0-FA-EB-11-70-04, Calling-Station-ID=90-1B-0E-34-EA-92, NAS-Port-Type=Ethernet, NAS-Port-Id=GigabitEthernet0/4, EAP-Key-Name=, cisco-av-pair=service-type=Call Check, cisco-av-pair=audit-session-id=0A06400F000006AA6F83C371, cisco-av-pair=method=mab, OriginalUserName=901b0e34ea92, NetworkDeviceProfileName=Cisco, NetworkDeviceProfileId=b2652f13-5b3f-41ba-ada2-8385c8870809, IsThirdPartyDeviceFlow=false, RadiusFlowType=WiredMAB, SSID=B0-FA-EB-11-70-04,\n")
     message = mt.render(mark="<165>", bsd=bsd, host=host, date=date, time=time, tzoffset=tzoffset)
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    # Generate new datetime for subsequent messages; not used in log path parser so actually could be anything
+    dt = datetime.datetime.now() + datetime.timedelta(seconds=1)
+    bsd = dt.strftime("%b %d %H:%M:%S")
 
     mt = env.from_string(
         "{{ mark }} {{ bsd }} {{ host }} CISE_Passed_Authentications 0001939187 4 1  AcsSessionID=ICDC-ISE03/341048949/1407358, AuthenticationIdentityStore=Internal Endpoints, AuthenticationMethod=Lookup, SelectedAccessService=Default Network Access, SelectedAuthorizationProfiles=WIRED_GUEST_REDIRECT, UseCase=Host Lookup, IdentityGroup=Endpoint Identity Groups:Unknown, Step=11001, Step=11017, Step=11027, Step=15049, Step=15008, Step=15048, Step=15048, Step=15041, Step=15013, Step=24209, Step=24211, Step=22037, Step=24715, Step=15036, Step=15048, Step=15048, Step=15016, Step=11002, SelectedAuthenticationIdentityStores=Internal Endpoints, AuthenticationStatus=AuthenticationPassed, NetworkDeviceGroups=Location#All Locations#Provo, NetworkDeviceGroups=Device Type#All Device Types#Switches, NetworkDeviceGroups=Migrated NDGs#All Migrated NDGs, IdentityPolicyMatchedRule=Default, AuthorizationPolicyMatchedRule=Guest Web Auth, UserType=Host, CPMSessionID=0A06400F000006AA6F83C371, EndPointMACAddress=90-1B-0E-34-EA-92,\n")
@@ -67,7 +71,7 @@ def test_cisco_ise_single(record_property, setup_wordlist, setup_splunk, setup_s
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
 
-    # Tune time functions for Cisco ACS
+    # Tune time functions for Cisco ISE
     time = time[:-3]
     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
     epoch = epoch[:-3]


### PR DESCRIPTION
* Add date-parser() functionality that does not filter, so that an alternate path can be taken in case of a missed parse.  This is useful to avoid message drops when unique ports are used and standard filtering mechanisms are bypassed.
* Useful for rogue event detection, particularly in multi-event sources such as Cisco ISE and ACS