### PR TITLE
Support OS syslog nested in Checkpoint event format

### DIFF
--- a/package/etc/conf.d/filters/checkpoint/splunk.conf
+++ b/package/etc/conf.d/filters/checkpoint/splunk.conf
@@ -1,6 +1,8 @@
 filter f_checkpoint_splunk {
     match('\|(?:origin_sic_name|originsicname)\=[cC][nN]|\|product\=SmartConsole\|' value("MSG") type("pcre")) or
-    match('\|(?:origin_sic_name|originsicname)\=[cC][nN]|\|product\=SmartConsole\|' value("LEGACY_MSGHDR") type("pcre"));
+    match('\|(?:origin_sic_name|originsicname)\=[cC][nN]|\|product\=SmartConsole\|' value("LEGACY_MSGHDR") type("pcre")) or
+    match('|product\=Syslog\|ifdir=inbound\|loguid\=' value("MSG") type("pcre")) or
+    match('|product\=Syslog\|ifdir=inbound\|loguid\=' value("LEGACY_MSGHDR") type("pcre"));
 };
 
 filter f_checkpoint_splunk_alerts {
@@ -55,4 +57,7 @@ filter f_checkpoint_splunk_NetworkTraffic {
 };
 filter f_checkpoint_splunk_Web {
     match('*Url Filtering*' value('.kv.product') type('glob'))
+};
+filter f_checkpoint_splunk_syslog {
+    match('Syslog' value('.kv.product') type('glob'))
 };

--- a/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
@@ -62,6 +62,25 @@ log {
             filter(f_checkpoint_splunk_DLP);
             rewrite { r_set_splunk_dest_default(sourcetype("cp_log"), source("firewall"), index("netdlp"))};
             parser {p_add_context_splunk(key("checkpoint_splunk_dlp")); };
+        } elif {
+            filter(f_checkpoint_splunk_syslog);
+            if {
+                    parser {
+                        syslog-parser(template("${.kv.default_device_message}") flags(guess-timezone, no-hostname));
+                        date-parser-nofilter(format("%s") template("${.kv.time}"));
+                    };
+            };
+            
+            rewrite {
+                    set("${.kv.hostname}", value("HOST"));
+                    set("checkpoint_splunk", value("fields.sc4s_vendor_product"));            
+                    subst("^[^\t]+\t", "", value("MESSAGE"), flags("global"));
+                    set("${PROGRAM}", value(".PROGRAM"));
+                    subst('^\/(?:[^\/]+\/)+', "" , value(".PROGRAM"));
+                };
+            rewrite { r_set_splunk_dest_default(sourcetype("nix:syslog"), index("netops"), source("program:${.PROGRAM}")) };
+            parser { p_add_context_splunk(key("checkpoint_os")); };                
+        
         };
     } else {
         filter(f_nix_syslog);

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../package
     hostname: sc4s
     #When this is enabled test_common will fail
-    #command: -det
+    command: -det
     ports:
       - "514"
       - "601"


### PR DESCRIPTION
This will unwrap the proper OS syslog event from the header when origin is the logger OS however it will not support third party relay via checkpoint in this format.