### PR TITLE
Fix 5424 preprocessor

### DIFF
--- a/package/etc/conf.d/conflib/_common/syslog_format.conf
+++ b/package/etc/conf.d/conflib/_common/syslog_format.conf
@@ -1,5 +1,5 @@
 filter f_rfc5424_strict{
-    message('^\<(?<PRI>\d+)\>(?<VERSION>\d{1,2})? (?<YEAR>\d+)-(?<MONTH>\d+)-(?<DAY>\d+)T(?<HOUR>\d+):(?<MINUTE>\d+):(?<SECOND>\d+)(?:\.(?<MILLISECONDS>\d+))?(?<OFFSET>Z|[\+-] *\d+:\d+) (?<HOSTNAME>(-)|[^ ]+) (?<APPNAME>(?:-)|\w+) (?<PROCID>(?:-)|\w+) (?<MSGID>(?:-)|\w+) *(?<STRUCDATA>(?:-)|\[.*?\]) *(?<MSG>(?:-)| .*)?$');
+    message('^\<(?<PRI>\d+)\>(?<VERSION>\d{1,2})? (?<YEAR>\d+)-(?<MONTH>\d+)-(?<DAY>\d+)T(?<HOUR>\d+):(?<MINUTE>\d+):(?<SECOND>\d+)(?:\.(?<MILLISECONDS>\d+))?(?<OFFSET>Z|[\+-] *\d+:\d+) (?<HOSTNAME>(-)|[^ ]+) (?<APPNAME>(?:-)|[!-~]+) (?<PROCID>(?:-)|[!-~]+) (?<MSGID>(?:-)|[!-~]+) *(?<STRUCDATA>(?:-)|\[.*?\]) *(?<MSG>(?:-)| .*)?$');
     };
 filter f_rfc5424_noversion{
     message('^(?<SYSLOGMSG>(?<HEADER>(?<PRI><\d{1,3}>) ?(?<TIMESTAMP>(?<FULLDATE>(?<FULLDATEYEAR>\d{4})-(?<FULLDATEMONTH>\d\d)-(?<FULLDATEDAY>\d\d))T(?<FULLTIME>(?<PARTIALTIME>(?<TIMEHOUR>[0-2]\d):(?<TIMEMINUTE>[0-5]\d):(?<TIMESECOND>[0-5]\d)(?:.(?<TIMESECFRAC>\d{1,6}))?)(?<TIMEOFFSET>Z|(?<TIMENUMOFFSET>[+\-][0-2]\d:[0-5]\d))))))');


### PR DESCRIPTION
* Refine 5424 preprocessor to allow all printable ASCII characters for `APPNAME`, `PROCID`, and `MSGID`.