### PR TITLE
removed cisco:pix and cisco:fwsm as it is going to deprecate in the l…

### DIFF
--- a/docs/sources/Cisco/index.md
+++ b/docs/sources/Cisco/index.md
@@ -110,8 +110,6 @@ Verify timestamp, and host values match as expected
 | sourcetype     | notes                                                                                                   |
 |----------------|---------------------------------------------------------------------------------------------------------|
 | cisco:asa      | cisco FTD Firepower will also use this source type                                                      |
-| cisco:pix      | Not supported                                                                                           |
-| cisco:fwsm     | Not supported                                                                                           |
 
 ### Sourcetype and Index Configuration
 


### PR DESCRIPTION
* Removed **cisco:pix** and **cisco:fwsm** as it is going to be deprecated in the latest add-on (v4.0.0)