### PR TITLE
Update metadata keys for Meraki and Zscaler

### DIFF
--- a/docs/sources/Cisco/index.md
+++ b/docs/sources/Cisco/index.md
@@ -291,7 +291,7 @@ Verify timestamp, and host values match as expected
 
 | sourcetype     | notes                                                                                                   |
 |----------------|---------------------------------------------------------------------------------------------------------|
-| merkai     | None                                                                                                    |
+| meraki     | None                                                                                                    |
 
 ### Sourcetype and Index Configuration
 

--- a/docs/sources/Zscaler/index.md
+++ b/docs/sources/Zscaler/index.md
@@ -25,13 +25,14 @@ the IP or host name of the SC4S instance and port 514
 
 ### Sourcetype and Index Configuration
 
-| key            | sourcetype     | index          | notes          |
-|----------------|----------------|----------------|----------------|
-| zscalernss_alerts      | zscalernss-alerts       | main          | none          |
-| zscalernss_dns      | zscalernss-dns     | netdns          | none          |
-| zscalernss_fw      | zscalernss-fw       | netfw          | none          |
-| zscalernss_web      | zscalernss-web       | netproxy          | none          |
-
+| key                 | sourcetype             | index    | notes   |
+|---------------------|------------------------|----------|---------|
+| zscaler_alerts      | zscalernss-alerts      | main     | none    |
+| zscaler_dns         | zscalernss-dns         | netdns   | none    |
+| zscaler_fw          | zscalernss-fw          | netfw    | none    |
+| zscaler_web         | zscalernss-web         | netproxy | none    |
+| zscaler_zia_audit   | zscalernss-zia-audit   | netops   | none    |
+| zscaler_zia_sandbox | zscalernss-zia-sandbox | main     | none    |
 
 ### Filter type
 
@@ -87,12 +88,12 @@ the IP or host name of the SC4S instance and port 514
 
 ### Sourcetype and Index Configuration
 
-| key            | sourcetype     | index          | notes          |
-|----------------|----------------|----------------|----------------|
-| zscalernss-zpa-app      | zscalerlss_zpa-app       | netproxy          | none          |
-| zscalernss-zpa-auth      | zscalerlss_zpa_auth       | netauth          | none          |
-| zscalernss-zpa-bba      | zscalerlss_zpa_auth       | netproxy          | none          |
-| zscalernss-zpa-connector    | zscalerlss_zpa_connector       | netproxy          | none          |
+| key            | sourcetype               | index      | notes   |
+|----------------|--------------------------|------------|---------|
+| zscaler_lss    | zscalerlss_zpa-app       | netproxy   | none    |
+| zscaler_lss    | zscalerlss_zpa_auth      | netproxy   | none    |
+| zscaler_lss    | zscalerlss_zpa_auth      | netproxy   | none    |
+| zscaler_lss    | zscalerlss_zpa_connector | netproxy   | none    |
 
 
 ### Filter type

--- a/package/etc/conf.d/log_paths/lp-zscaler_lss.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zscaler_lss.conf.tmpl
@@ -74,7 +74,7 @@ log {
             match('.' value('.json.SAMLAttributes'))
             and match('.' value('.json.Customer'))
         };
-        rewrite { r_set_splunk_dest_default(sourcetype("zscalerlss-zpa-auth"), index("netauth"))};
+        rewrite { r_set_splunk_dest_default(sourcetype("zscalerlss-zpa-auth"), index("netproxy"))};
         parser { p_add_context_splunk(key("zscaler_lss")); };
         parser (compliance_meta_by_source);
         rewrite { set("$(template ${.splunk.sc4s_template} $(template t_msg_only))" value("MSG")); };    

--- a/package/etc/context_templates/splunk_index.csv.example
+++ b/package/etc/context_templates/splunk_index.csv.example
@@ -70,3 +70,10 @@
 #sc4s_metrics,index,em_metrics
 #symanrtec_ep,index,epav
 #vmware_nsx,index,main
+#zscaler_alerts,index,main
+#zscaler_dns,index,netdns
+#zscaler_fw,index,netfw
+#zscaler_web,index,netproxy
+#zscaler_zia_audit,index,netops
+#zscaler_zia_sandbox,index,main
+#zscaler_lss,index,netproxy

--- a/tests/test_zscaler_proxy.py
+++ b/tests/test_zscaler_proxy.py
@@ -247,7 +247,7 @@ def test_zscaler_lss_zpa_auth(record_property, setup_wordlist, setup_splunk, set
     message = mt.render(mark="<134>", lss_time=lss_time, host=host)
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-    st = env.from_string("search _time={{ epoch }} index=netauth sourcetype=\"zscalerlss-zpa-auth\" \"{{host}}\"")
+    st = env.from_string("search _time={{ epoch }} index=netproxy sourcetype=\"zscalerlss-zpa-auth\" \"{{host}}\"")
     search = st.render(epoch=epoch, host=host)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)


### PR DESCRIPTION
* Fix incorrect Meraki and Zscaler keys in docs
* Change zscaler LSS `zpa-auth` logs to use `netproxy` index (to match all other LSS events).