### PR TITLE
Update 5424 templates to include RAWMSG

### DIFF
--- a/package/etc/conf.d/conflib/_common/templates.conf
+++ b/package/etc/conf.d/conflib/_common/templates.conf
@@ -80,6 +80,7 @@ template t_JSON_5424 {
     template('$(format-json --scope rfc5424
                 --pair PRI="<$PRI>"
                 --key ISODATE
+                --key RAWMSG
                 --exclude DATE
                 --exclude FACILITY
                 --exclude PRIORITY
@@ -95,6 +96,7 @@ template t_JSON_5424_SDATA {
     template('$(format-json --scope rfc5424
                 --pair PRI="<$PRI>"
                 --key ISODATE
+                --key RAWMSG
                 --exclude DATE
                 --exclude HOST
                 --exclude FACILITY


### PR DESCRIPTION
* Update 5424 output templates to include RAWMSG.  Too confusing for most users without it, and there are some small parts of the message that are excluded (such as colons) that are needed to reassemble the raw message with the constituent macros.