### PR TITLE
Update conntrack unit file entry with required space

### DIFF
--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -19,10 +19,12 @@ to install and run it each time sc4s starts.  It should be available in all RHEL
 <dnf or yum> install conntrack
 ```
 
-After this is done, add the following entry to the unit file (and/or use the command when starting sc4s manually):
+After this is done, add the following entry to the unit file (and/or use the command when starting sc4s manually).
+Note that the space on either side of the semicolon in the `ExecStartPost` entry is _required_ and systemd
+will error out if it is missing.
 
 ```
-ExecStartPost=sleep 2; conntrack -D -p udp
+ExecStartPost=sleep 2 ; conntrack -D -p udp
 ```
 
 This command will delete the old (stale) UDP entries two seconds after the container starts and allow the system to build a new table that
@@ -82,7 +84,7 @@ ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 6514:6514 \
         "$SC4S_TLS_DIR" \
         --name SC4S \
         --rm $SC4S_IMAGE
-ExecStartPost=sleep 2; conntrack -D -p udp
+ExecStartPost=sleep 2 ; conntrack -D -p udp
 ```
 
 * Execute the following command to create a local volume that will contain the disk buffer files in the event of a communication


### PR DESCRIPTION
* `ExecStartPost` command requires a space around the semicolon separating the two individual commands.