### PR TITLE
Update lookahead for metrics regex

### DIFF
--- a/package/etc/conf.d/log_paths/lp-sc4s_internal.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-sc4s_internal.conf.tmpl
@@ -9,7 +9,7 @@ log {
         rewrite {
             subst('.*Log statistics; ', '', value("MESSAGE"), flags("utf8" "global"));
             subst('([^= ]+=\x27[^\(]+\(#anon[^,\)]+(?:,[^,]+,[^\)]+)?\)\=\d+\x27(?:, )?)', '', value("MESSAGE"), flags("utf8" "global"));
-            subst('(?<Type>[^= ]+)=\x27(?<SourceName>[^\(]+)\((?<SourceId>\S+(?=\)=))(?:,(?<SourceInstance>[^,]+),(?<State>[^\)]+))?\)\=(?<Number>\d+)\x27,? ?',
+            subst('(?<Type>[^= ]+)=\x27(?<SourceName>[^\(]+)\((?<SourceId>\S+(?=\)[=,]))(?:,(?<SourceInstance>[^,]+),(?<State>[^\)]+))?\)\=(?<Number>\d+)\x27,? ?',
 '{"time": "$S_UNIXTIME","event": "metric","host": "$HOST","index": "${.splunk.index}","source": "internal","sourcetype": "${.splunk.sourcetype}","fields": {"source_name": "${SourceName}","source_instance": "${SourceInstance}","state": "${State}","type": "${Type}","_value": ${Number},"metric_name": "syslogng.${SourceId}"}}
 ',
                      value("MESSAGE") flags("utf8" "global")


### PR DESCRIPTION
* Update lookahead in `lp-sc4s_internal.conf.tmpl` to include _either_ a `=` or `,` character in the lookahead for SourceID