### PR TITLE
Supress `Destination timeout has elapsed` info message

### DIFF
--- a/package/etc/conf.d/destinations/splunk_hec_debug.conf.tmpl
+++ b/package/etc/conf.d/destinations/splunk_hec_debug.conf.tmpl
@@ -9,5 +9,6 @@ destination d_hec_debug {
                  event=$MSG
                  fields.*)'\n")
         create_dirs(yes)
+        time-reap(0)
    );
 };


### PR DESCRIPTION
* Update `splunk_hec_debug.conf.tmpl` to include `time-reap(0)` in file destination to supress unnecessary  `Destination timeout has elapsed` info messages every minute