### PR TITLE
Fix `date-parser()` template

### DIFF
--- a/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
@@ -37,7 +37,7 @@ log {
             #parse the date
             date-parser-nofilter(format(
                     '%Y-%m-%d %H:%M:%S,%f')
-                    template("${.rsa.time},${.rsa.ms}")
+                    template("${.rsa.time} ${.rsa.ms}")
             );
         };
         if {


### PR DESCRIPTION
* Fix `date-parser-nofilter()` template argument (space rather than comma)