### PR TITLE
Improve startup process

### DIFF
--- a/docs/gettingstarted/docker-systemd-general.md
+++ b/docs/gettingstarted/docker-systemd-general.md
@@ -52,14 +52,8 @@ Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.
 TimeoutStartSec=0
 Restart=always
 
-ExecStartPre=/usr/bin/docker pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
-ExecStartPre=/usr/bin/docker run \
-        --env-file=/opt/sc4s/env_file \
-        "$SC4S_LOCAL_CONFIG_MOUNT" \
-        --name SC4S_preflight \
-        --rm $SC4S_IMAGE -s
-ExecStart=/usr/bin/docker run -p 514:514 -p 514:514/udp -p 6514:6514 \
+ExecStart=/usr/bin/docker run –pull=always -p 514:514 -p 514:514/udp -p 6514:6514 \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         --env-file=/opt/sc4s/env_file \
         "$SC4S_PERSIST_VOLUME" \
@@ -68,6 +62,7 @@ ExecStart=/usr/bin/docker run -p 514:514 -p 514:514/udp -p 6514:6514 \
         "$SC4S_TLS_DIR" \
         --name SC4S \
         --rm $SC4S_IMAGE
+Restart=on-success
 ```
 
 * Execute the following command to create a local volume that will contain the disk buffer files in the event of a communication

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -70,8 +70,14 @@ Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.
 TimeoutStartSec=0
 Restart=always
 
+ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
-ExecStart=/usr/bin/podman run –pull=always -p 514:514 -p 514:514/udp -p 6514:6514 \
+ExecStartPre=/usr/bin/podman run \
+        --env-file=/opt/sc4s/env_file \
+        "$SC4S_LOCAL_CONFIG_MOUNT" \
+        --name SC4S_preflight \
+        --rm $SC4S_IMAGE -s
+ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 6514:6514 \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         --env-file=/opt/sc4s/env_file \
         "$SC4S_PERSIST_VOLUME" \
@@ -80,7 +86,8 @@ ExecStart=/usr/bin/podman run –pull=always -p 514:514 -p 514:514/udp -p 6514:6
         "$SC4S_TLS_DIR" \
         --name SC4S \
         --rm $SC4S_IMAGE
-Restart=on-successck -D -p udp
+ExecStartPost=sleep 2 ; conntrack -D -p udp
+Restart=on-success
 ```
 
 * Execute the following command to create a local volume that will contain the disk buffer files in the event of a communication

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -70,14 +70,8 @@ Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.
 TimeoutStartSec=0
 Restart=always
 
-ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
-ExecStartPre=/usr/bin/podman run \
-        --env-file=/opt/sc4s/env_file \
-        "$SC4S_LOCAL_CONFIG_MOUNT" \
-        --name SC4S_preflight \
-        --rm $SC4S_IMAGE -s
-ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 6514:6514 \
+ExecStart=/usr/bin/podman run –pull=always -p 514:514 -p 514:514/udp -p 6514:6514 \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         --env-file=/opt/sc4s/env_file \
         "$SC4S_PERSIST_VOLUME" \
@@ -86,7 +80,7 @@ ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 6514:6514 \
         "$SC4S_TLS_DIR" \
         --name SC4S \
         --rm $SC4S_IMAGE
-ExecStartPost=sleep 2 ; conntrack -D -p udp
+Restart=on-successck -D -p udp
 ```
 
 * Execute the following command to create a local volume that will contain the disk buffer files in the event of a communication

--- a/docs/gettingstarted/podman-systemd-general.md
+++ b/docs/gettingstarted/podman-systemd-general.md
@@ -70,14 +70,8 @@ Environment="SC4S_LOCAL_CONFIG_MOUNT=-v /opt/sc4s/local:/opt/syslog-ng/etc/conf.
 TimeoutStartSec=0
 Restart=always
 
-ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
-ExecStartPre=/usr/bin/podman run \
-        --env-file=/opt/sc4s/env_file \
-        "$SC4S_LOCAL_CONFIG_MOUNT" \
-        --name SC4S_preflight \
-        --rm $SC4S_IMAGE -s
-ExecStart=/usr/bin/podman run -p 514:514 -p 514:514/udp -p 6514:6514 \
+ExecStart=/usr/bin/podman run –pull=always -p 514:514 -p 514:514/udp -p 6514:6514 \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         --env-file=/opt/sc4s/env_file \
         "$SC4S_PERSIST_VOLUME" \

--- a/package/etc/conf.d/filters/cisco/cisco_syslog.conf
+++ b/package/etc/conf.d/filters/cisco/cisco_syslog.conf
@@ -9,7 +9,6 @@ filter f_is_cisco_syslog{
 };
 
 parser cisco-parser-ex{
-    x
     channel {
         if {
             #Cisco IOS-XR devices with node-id format

--- a/package/etc/conf.d/filters/cisco/cisco_syslog.conf
+++ b/package/etc/conf.d/filters/cisco/cisco_syslog.conf
@@ -9,6 +9,7 @@ filter f_is_cisco_syslog{
 };
 
 parser cisco-parser-ex{
+    x
     channel {
         if {
             #Cisco IOS-XR devices with node-id format

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -56,6 +56,14 @@ echo syslog-ng starting
 
 /opt/syslog-ng/sbin/syslog-ng $@ &
 pid="$!"
+sleep 5
+if ! ps -p $pid > /dev/null
+then
+   echo "syslog-ng failed to start $pid is not running"
+   exit 99
+   # Do something knowing the pid exists, i.e. the process with $PID is running
+fi
+
 # wait forever
 if [[ $@ != *"-s"* ]]; then
   while true

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -60,7 +60,7 @@ sleep 5
 if ! ps -p $pid > /dev/null
 then
    echo "syslog-ng failed to start $pid is not running"
-   exit 99
+   exit $(wait ${pid})
    # Do something knowing the pid exists, i.e. the process with $PID is running
 fi
 


### PR DESCRIPTION
- When starting up check the pid and exit the container if it is not running on startup failure return the syslog-ng error code to systemd.
- Remove deprecated preflight checks from the systemd unit examples. Existing users can remove or continue these checks with no consequences non breaking
