### PR TITLE
Update `em_metrics` index creation as optional

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -45,7 +45,7 @@ using the SC4S defaults. SC4S can be easily customized to use different indexes 
 * netipam
 * oswinsec
 * osnix
-* em_metrics (ensure this is created as a metrics index)
+* em_metrics (Optional opt-in for SC4S operational metrics; ensure this is created as a metrics index)
 
 #### Install Related Splunk Apps
 


### PR DESCRIPTION
* Update prerequisites in docs to indicate that the `em_metrics` index is optional now that metrics is opt-in.