### PR TITLE
ADDON-26524: Modified log_path file for Cisco ISE

### DIFF
--- a/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
@@ -91,7 +91,7 @@ log {
 
         parser {p_add_context_splunk(key("cisco_ise")); };
         parser (compliance_meta_by_source);
-        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_msg_only))" value("MSG")); };
+        rewrite { set("$(template ${.splunk.sc4s_template} $(template t_hdr_msg))" value("MSG")); };
 
 {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_CISCO_ISE_HEC" "no")) }}
         destination(d_hec);


### PR DESCRIPTION
We have changed the template to **t_hdr_msg** from **t_msg_only** of lp-cisco_ise.conf.tmpl file for Cisco ISE add-on as the CIM mapping is defined using **CISE_*** string and we were unable to get that string using **t_msg_only** template as the header part was getting removed.
So to overcome that, we have used **t_hdr_msg** template and we are able to get that string.
Link to JIRA: https://jira.splunk.com/browse/ADDON-26524