### PR TITLE
Remove ISODATE from 5424 JSON format

### DIFF
--- a/package/etc/conf.d/conflib/_common/templates.conf
+++ b/package/etc/conf.d/conflib/_common/templates.conf
@@ -93,6 +93,7 @@ template t_JSON_5424 {
     template('$(format-json --scope rfc5424
                 --key RAWMSG
                 --exclude DATE
+                --exclude ISODATE
                 --exclude FACILITY
                 --exclude PRIORITY
                 --exclude HOST

--- a/package/etc/conf.d/conflib/_common/templates.conf
+++ b/package/etc/conf.d/conflib/_common/templates.conf
@@ -96,6 +96,7 @@ template t_JSON_5424 {
                 --exclude ISODATE
                 --exclude FACILITY
                 --exclude PRIORITY
+                --exclude PRI
                 --exclude HOST
                 )');
     };

--- a/package/etc/conf.d/conflib/_common/templates.conf
+++ b/package/etc/conf.d/conflib/_common/templates.conf
@@ -121,9 +121,11 @@ template t_JSON_5424_ALL {
 template t_JSON_5424_SDATA {
     template('$(format-json --scope rfc5424
                 --exclude DATE
+                --exclude ISODATE
                 --exclude HOST
                 --exclude FACILITY
                 --exclude PRIORITY
+                --exclude PRI
                 --exclude MESSAGE
                 --exclude RAWMSG
                 )');


### PR DESCRIPTION
ISODATE is redundant and not required