### PR TITLE
Fixed the issue of CISE_Alarm events for Cisco ISE

### DIFF
--- a/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
@@ -73,17 +73,28 @@ log {
     };
 
 # Do not run the events through the group parser if there is only one event
-    parser(ise_get_sequence);
-    if (match("1" value("ISE.num"))) {
-        rewrite { set("yes" value("ISE.COMPLETE"));
+    if (program('CISE_Alarm')) {
+        rewrite {
+            set("yes" value("ISE.COMPLETE"));
         };
     } else {
-        parser(ise_grouping);
+        parser(ise_get_sequence);
+        if (match("1" value("ISE.num"))) {
+            rewrite { set("yes" value("ISE.COMPLETE"));
+            };
+        } else {
+            parser(ise_grouping);
+        };
     };
 
     if {
         filter(f_cisco_ise_complete);
-        parser(ise_event_time);
+        if {
+            filter {
+                "${PROGRAM}" != "CISE_Alarm"
+            };
+            parser(ise_event_time);
+        };
         rewrite {
             set("cisco_ise", value("fields.sc4s_vendor_product"));
             r_set_splunk_dest_default(sourcetype("cisco:ise:syslog"))

--- a/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-cisco_ise.conf.tmpl
@@ -91,7 +91,7 @@ log {
         filter(f_cisco_ise_complete);
         if {
             filter {
-                "${PROGRAM}" != "CISE_Alarm"
+                not program('CISE_Alarm');
             };
             parser(ise_event_time);
         };


### PR DESCRIPTION
CISE_Alarm events of Cisco ISE, Do not contain `ISE.num`, `ISE.seq`, etc fields and the format is different than other CISE_* fields. Hence added a check that if the event is CISE_Alarm then index the event as is and do not wait to group it with others.