### PR TITLE
* Add host override for compliance_meta

### DIFF
--- a/package/etc/conf.d/conflib/_splunk/splunkfields.conf.tmpl
+++ b/package/etc/conf.d/conflib/_splunk/splunkfields.conf.tmpl
@@ -1,6 +1,7 @@
 #Used to set indexed fields we will always use to global defaults
 rewrite r_set_splunk_default {
     set("SC4S:$SOURCE", value(".splunk.source"));
+    set("$HOST", value(".splunk.host"));
 {{- if (has (split (getenv "SC4S_DEST_SPLUNK_INDEXED_FIELDS" "facility") ",") "facility") }}
     set($FACILITY, value("fields.sc4s_syslog_facility"));
 {{- end}}      
@@ -38,11 +39,13 @@ rewrite r_set_splunk_default {
 block rewrite r_set_splunk_dest_default(
                               #While the following is not used it remains to prevent breaking changes in content
                               index("{{- getenv "SC4S_DEST_SPLUNK_HEC_FALLBACK_INDEX" }}")
+                              host("${HOST}")
                               source("${.splunk.source}")                              
                               sourcetype()
                               template(`splunk-template`)
                            ) {
       set("`index`", value(".splunk.index"));
+      set("`host`", value(".splunk.host"));
       set("`source`", value(".splunk.source"));
       set("`sourcetype`", value(".splunk.sourcetype"));
 };

--- a/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-checkpoint_splunk.conf.tmpl
@@ -44,8 +44,6 @@ log {
            #The LM is the host that will always be in use so we set and save it
            set("${.kv.hostname}", value("HOST"));
            set("${.kv.hostname}", value("fields.cp_lm"));
-           set("checkpoint_splunk", value("fields.sc4s_vendor_product"));
-           r_set_splunk_dest_default(sourcetype("cp_log"))
         };
         
         if {
@@ -75,7 +73,11 @@ log {
                 set("$1", value("HOST"));               
             };
         };            
-        
+
+        rewrite {
+           set("checkpoint_splunk", value("fields.sc4s_vendor_product"));
+           r_set_splunk_dest_default(sourcetype("cp_log"))
+        };
         
         if {
             parser {p_add_context_splunk(key("checkpoint_splunk")); };

--- a/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-paloalto_panos.conf.tmpl
@@ -148,6 +148,9 @@ log {
         parser {p_add_context_splunk(key("pan_log")); };
     };
     rewrite {
+        #Set both HOST and .splunk.host to allow compliance override
+        set("${.pan.dvc_name}" value(".splunk.host")
+            condition( match('^.' value('.pan.dvc_name') )) );
         set("${.pan.dvc_name}" value("HOST") 
             condition( match('^.' value('.pan.dvc_name') )) );
     };

--- a/package/etc/go_templates/splunk_hec.t
+++ b/package/etc/go_templates/splunk_hec.t
@@ -44,7 +44,7 @@ destination d_hec{{ .var_id }} {
          ca-file("{{- getenv (print "SC4S_DEST_SPLUNK_HEC" .var_id "_TLS_CA_FILE") "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"}}"))
          body('$(format-json
                  time=$S_UNIXTIME
-                 host=${HOST}
+                 host=${.splunk.host}
                  source=${.splunk.source}
                  sourcetype=${.splunk.sourcetype}
                  index=${.splunk.index}


### PR DESCRIPTION
* Add host override capability to `compliance_meta_by_source`
* Adjust HOST settings in CHPT and Palo log paths to accommodate this change
* Addresses https://github.com/splunk/splunk-connect-for-syslog/issues/572