### PR TITLE
[filtermod] cisco date parser issues

### DIFF
--- a/package/etc/conf.d/filters/cisco/cisco_syslog.conf
+++ b/package/etc/conf.d/filters/cisco/cisco_syslog.conf
@@ -102,17 +102,23 @@ parser cisco-parser-ex{
                 filter {
                     match('^(\*|\.)$' value("7"));
                 };
-                rewrite { set("cisco reported time error : ${8}" value("fields.sc4s_error")); };
+                rewrite { set("cisco reported time error : ${7}" value("fields.cisco_time_error")); };
             } else {
-                parser { date-parser-nofilter(format(
-                    '%b %d %H:%M:%S.%f',
-                    '%b %d %H:%M:%S',
-                    '%b %d %I:%M:%S %p.%f',
-                    '%b %d %I:%M:%S %p',
-                    '%b %d %Y %H:%M:%S.%f',
-                    '%b %d %Y %H:%M:%S')
-                    template("$8"));
-                };                
+                if {
+                    filter {
+                        match('^\w\w\w' value("8"));
+                    };
+                    parser { date-parser-nofilter(format(
+                        '%b %d %H:%M:%S.%f',
+                        '%b %d %H:%M:%S',
+                        '%b %d %I:%M:%S %p.%f',
+                        '%b %d %I:%M:%S %p',
+                        '%b %d %Y %H:%M:%S.%f',
+                        '%b %d %H:%M:%S.%f',
+                        '%b %d %Y %H:%M:%S')
+                        template("$8"));
+                    };                
+                };
             };
         } else {
             #Cisco AireOS format

--- a/package/etc/conf.d/filters/cisco/cisco_syslog.conf
+++ b/package/etc/conf.d/filters/cisco/cisco_syslog.conf
@@ -102,8 +102,9 @@ parser cisco-parser-ex{
                 filter {
                     match('^(\*|\.)$' value("7"));
                 };
-                rewrite { set("cisco reported time error : ${7}" value("fields.cisco_time_error")); };
-            } else {
+                rewrite { set("cisco reported time error : ${7}" value("fields.cisco_time_error"));
+            };
+            if {
                 if {
                     filter {
                         match('^\w\w\w' value("8"));


### PR DESCRIPTION
False error reported when cisco device sends uptime
device reported time errors will now use the indexed field cisco_time_error
Add micro seconds format without year