### PR TITLE
RSA SecurID timestamps

### DIFF
--- a/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
@@ -37,7 +37,7 @@ log {
             #parse the date
             date-parser-nofilter(format(
                     '%Y-%m-%d %H:%M:%S,%f')
-                    template("${.rsa.time} ${.rsa.ms}")
+                    template("${LEGACY_MSGHDR} ${.rsa.time},${.rsa.ms}")
             );
         };
         if {

--- a/tests/test_dell_rsa_secureid.py
+++ b/tests/test_dell_rsa_secureid.py
@@ -31,10 +31,10 @@ def test_dell_rsa_secureid_admin(
 
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
-    rsatime = dt.strftime("%H:%M:%S,%f")
+    rsatime = dt.strftime("%H:%M:%S,%f")[:-3]
 
     # Tune time functions
-    epoch = epoch[:-7]
+    epoch = epoch[:-3]
 
     mt = env.from_string(event + "\n")
     message = mt.render(mark="<166>", bsd=bsd, host=host, date=date, rsatime=rsatime)
@@ -65,10 +65,10 @@ def test_dell_rsa_secureid_system(
 
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
-    rsatime = dt.strftime("%H:%M:%S,%f")
+    rsatime = dt.strftime("%H:%M:%S,%f")[:-3]
 
     # Tune time functions
-    epoch = epoch[:-7]
+    epoch = epoch[:-3]
 
     mt = env.from_string(event + "\n")
     message = mt.render(mark="<166>", bsd=bsd, host=host, date=date, rsatime=rsatime)
@@ -99,10 +99,10 @@ def test_dell_rsa_secureid_runtime(
 
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
-    rsatime = dt.strftime("%H:%M:%S,%f")
+    rsatime = dt.strftime("%H:%M:%S,%f")[:-3]
 
     # Tune time functions
-    epoch = epoch[:-7]
+    epoch = epoch[:-3]
 
     mt = env.from_string(event + "\n")
     message = mt.render(mark="<166>", bsd=bsd, host=host, date=date, rsatime=rsatime)
@@ -147,13 +147,12 @@ def test_dell_rsa_secureid_trace(
     ]
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
-    rsatime = dt.strftime("%H:%M:%S,%f")
 
     # Tune time functions
     epoch = epoch[:-7]
     for event in events:
         mt = env.from_string(event + "\n")
-        message = mt.render(mark="<166>", bsd=bsd, host=host, date=date, rsatime=rsatime)
+        message = mt.render(mark="<166>", bsd=bsd, host=host, date=date)
         sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(


### PR DESCRIPTION
* Fix time/date parsing in RSA SecurID
* Nit: Should fix all references to this source as `SecurID` (with no "e")