### PR TITLE
[filtermod] cef correct template for imperva securesphere

### DIFF
--- a/package/etc/conf.d/conflib/_common/templates.conf
+++ b/package/etc/conf.d/conflib/_common/templates.conf
@@ -34,10 +34,6 @@ template t_everything {
         template("${ISODATE} ${HOST} ${LEGACY_MSGHDR}${MESSAGE}");
         };
 
-template t_cef_hdr_msg_for_esa {
-        template("${fields.cef_version}|${fields.cef_device_vendor}|${fields.cef_device_product}|${fields.cef_device_version}|${fields.cef_device_event_class}|${fields.cef_name}|${fields.cef_severity}|${MSGONLY}");
-        };  
-
 # ===============================================================================================
 # Message Header with Message; for Palo Alto
 # ===============================================================================================

--- a/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
@@ -5,13 +5,13 @@
 
 parser p_cef_header {
     csv-parser(
-        columns("fields.cef_version", "fields.cef_device_vendor", "fields.cef_device_product", "fields.cef_device_version", "fields.cef_device_event_class", "fields.cef_name", "fields.cef_severity", MESSAGE)
+        columns("fields.cef_version", "fields.cef_device_vendor", "fields.cef_device_product", "fields.cef_device_version", "fields.cef_device_event_class", "fields.cef_name", "fields.cef_severity", ".cef.message")
         delimiters(chars("|"))
         template(t_legacy_hdr_msg)
         flags(strip-whitespace, escape-none, greedy)
     );
 
-    kv-parser(prefix(".cef.") template("t_msg_trim")
+    kv-parser(prefix(".cef.") template("${.cef.message}")
     );
 
 };
@@ -51,6 +51,10 @@ parser p_cef_class {
 template t_cef_hdr_msg {
         template("$(strip $MESSAGE )");
         };
+
+template t_cef_kv {
+        template("$(strip $MESSAGE )");
+        };        
 
 log {
     junction {
@@ -106,7 +110,7 @@ log {
 
     parser (compliance_meta_by_source);
 
-    rewrite { set("$(template ${.splunk.sc4s_template} $(template t_msg_only))" value("MSG")); };
+    rewrite { set("$(template ${.splunk.sc4s_template} $(template t_legacy_hdr_msg))" value("MSG")); };
 
 {{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_CEF_HEC" "no")) }}
     destination(d_hec);

--- a/package/etc/context_templates/splunk_metadata.csv.example
+++ b/package/etc/context_templates/splunk_metadata.csv.example
@@ -11,10 +11,10 @@ CyberArk_PTA,sourcetype,cyberark:pta:cef
 Incapsula_SIEMintegration,index,netwaf
 Incapsula_SIEMintegration,source,Imperva:Incapsula
 Incapsula_SIEMintegration,sourcetype,cef
-Incapsula_SIEMintegration,sc4s_template,t_cef_hdr_msg
+Incapsula_SIEMintegration,sc4s_template,t_cef_kv
 Imperva Inc._SecureSphere,index,netwaf
 Imperva Inc._SecureSphere,sourcetype,imperva:waf
-Imperva Inc._SecureSphere,sc4s_template,t_cef_hdr_msg
+Imperva Inc._SecureSphere,sc4s_template,t_legacy_hdr_msg
 Imperva Inc._SecureSphere_Firewall,sourcetype,imperva:waf:firewall:cef
 Imperva Inc._SecureSphere_Signature,sourcetype,imperva:waf:security:cef
 Imperva Inc._SecureSphere_Protocol,sourcetype,imperva:waf:security:cef
@@ -121,7 +121,7 @@ unknown,index,main
 unknown,source,SC4S:unknown
 unknown,sourcetype,SC4S:unknown
 Cisco_C100V Email Security Virtual Appliance_ESA_CONSOLIDATED_LOG_EVENT,index,email
-Cisco_C100V Email Security Virtual Appliance_ESA_CONSOLIDATED_LOG_EVENT,sc4s_template,t_cef_hdr_msg_for_esa
+Cisco_C100V Email Security Virtual Appliance_ESA_CONSOLIDATED_LOG_EVENT,sc4s_template,t_legacy_hdr_msg
 Cisco_C100V Email Security Virtual Appliance_ESA_CONSOLIDATED_LOG_EVENT,sourcetype,cisco:esa:cef
 Cisco_C100V Email Security Virtual Appliance_ESA_CONSOLIDATED_LOG_EVENT,source,esa:consolidated
 cisco_esa,index,email


### PR DESCRIPTION
Change the default CEF and Imperva template to t_legacy_hdr_msg which will include the full header