### PR TITLE
Fix host parsing in RSA log path

### DIFF
--- a/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-dell_rsa_secureid.conf.tmpl
@@ -29,7 +29,7 @@ log {
 
             #we need to actual even time from the field GeneratedTime. Use csv-parser to extract it.
             csv-parser(
-                columns("time","ms","HOST","type")
+                columns("time","ms","host","type")
                 prefix(".rsa.")
                 delimiters(',')
                 );
@@ -39,6 +39,13 @@ log {
                     '%Y-%m-%d %H:%M:%S,%f')
                     template("${LEGACY_MSGHDR} ${.rsa.time},${.rsa.ms}")
             );
+        };
+        rewrite {
+            #Set both HOST and .splunk.host to allow compliance override
+            set("${.rsa.host}" value(".splunk.host")
+                condition( match('^.' value('.rsa.host') )) );
+            set("${.rsa.host}" value("HOST")
+                condition( match('^.' value('.rsa.host') )) );
         };
         if {
             filter{match('audit\.admin' value('.rsa.type'))};


### PR DESCRIPTION
* Fix host parsing in RSA log path to take into account the new `.splunk.host` macro for host output in Splunk `/event` JSON blob