### PR TITLE
[fix] Return to prior behavior to not change splunk_metadata

### DIFF
--- a/package/etc/conf.d/conflib/_splunk/splunk_context.conf
+++ b/package/etc/conf.d/conflib/_splunk/splunk_context.conf
@@ -1,7 +1,7 @@
 block parser p_add_context_splunk(key("syslogng-fallback")) {
     add-contextual-data(
         selector("`key`"),
-        database("conf.d/local/context/splunk_metadata.csv"),
+        database("conf.d/merged/context/splunk_metadata.csv"),
         prefix(".splunk.")
     );
 };

--- a/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-common_event_format.conf.tmpl
@@ -38,7 +38,7 @@ parser p_cef_ts_end {
 parser p_cef_class {
     add-contextual-data(
         selector("${fields.cef_device_vendor}_${fields.cef_device_product}_${fields.cef_device_event_class}"),
-        database("conf.d/local/context/splunk_metadata.csv")
+        database("conf.d/merged/context/splunk_metadata.csv")
         ignore-case(yes)
         prefix(".splunk.")
     );

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -47,7 +47,9 @@ trap 'kill ${!}; hup_handler' SIGHUP
 trap 'kill ${!}; term_handler' SIGTERM
 
 mkdir -p /opt/syslog-ng/etc/conf.d/local/context/
+mkdir -p /opt/syslog-ng/etc/conf.d/merged/context/
 mkdir -p /opt/syslog-ng/etc/conf.d/local/config/
+
 
 
 cp /opt/syslog-ng/etc/context_templates/* /opt/syslog-ng/etc/conf.d/local/context
@@ -59,7 +61,7 @@ then
   # Add new entries
   temp_file=$(mktemp)
   awk '{print $0}' /opt/syslog-ng/etc/conf.d/configmap/context/splunk_metadata.csv /opt/syslog-ng/etc/context_templates/splunk_metadata.csv.example | grep -v '^#' | sort -b -t ',' -k1,2 -u  > $temp_file
-  cp -f $temp_file /opt/syslog-ng/etc/conf.d/local/context/splunk_metadata.csv
+  cp -f $temp_file /opt/syslog-ng/etc/conf.d/merged/context/splunk_metadata.csv
 
 else
   # splunk_index.csv updates
@@ -72,7 +74,7 @@ else
   # Add new entries
   temp_file=$(mktemp)
   awk '{print $0}' ${LEGACY_SPLUNK_INDEX_FILE} /opt/syslog-ng/etc/conf.d/local/context/splunk_metadata.csv /opt/syslog-ng/etc/context_templates/splunk_metadata.csv.example | grep -v '^#' | sort -b -t ',' -k1,2 -u  > $temp_file
-  cp -f $temp_file /opt/syslog-ng/etc/conf.d/local/context/splunk_metadata.csv
+  cp -f $temp_file /opt/syslog-ng/etc/conf.d/merged/context/splunk_metadata.csv
   # We don't need this file any longer
   rm -f /opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv.example || true 
   if [ -f /opt/syslog-ng/etc/conf.d/local/context/splunk_index.csv ]; then


### PR DESCRIPTION
When SC4S consolidated configuration to use splunk_metadata.csv we created a single merged file with the defaults and customer updates. This has become problematic as corrections to defaults are not be applied. Going forward splunk_metadata.csv will be treated as a "default" and "local" where the local file should only have customizations. Customers can remove non-customized lines.