### PR TITLE
Simplify `vendor_product_by_source` parser

### DIFF
--- a/package/etc/conf.d/conflib/_common/p_vendor_product_by_source.conf
+++ b/package/etc/conf.d/conflib/_common/p_vendor_product_by_source.conf
@@ -1,4 +1,4 @@
-block parser vendor_product_by_source() {
+parser vendor_product_by_source {
     add-contextual-data(
         selector(filters("`syslog-ng-sysconfdir`/conf.d/local/context/vendor_product_by_source.conf")),
         database("conf.d/local/context/vendor_product_by_source.csv")

--- a/package/etc/conf.d/sources/rfc5687.conf.tmpl
+++ b/package/etc/conf.d/sources/rfc5687.conf.tmpl
@@ -17,8 +17,6 @@ source s_ietf {
             parser { app-parser(topic(syslog)); };
         };
         rewrite(set_rfc5424_strict);
-        parser {
-                vendor_product_by_source();
-        };
+        parser(vendor_product_by_source);
     };
 };

--- a/package/etc/go_templates/source_network.t
+++ b/package/etc/go_templates/source_network.t
@@ -272,9 +272,7 @@ source s_{{ .port_id }} {
             parser(p_fix_host_resolver);
         };
         {{ end }}
-        parser {            
-            vendor_product_by_source();            
-        };
+        parser(vendor_product_by_source);
 
         if {
             filter { match("." value("fields.sc4s_time_zone") ) };


### PR DESCRIPTION
* Remove block function for `vendor_product_by source` parser; simplify calling syntax
* Rename parser file in `_common` to `p_vendor_product_by_source.conf` to align with naming convention