### PR TITLE
Change reverse DNS default to "no"

### DIFF
--- a/package/etc/go_templates/source_network.t
+++ b/package/etc/go_templates/source_network.t
@@ -255,7 +255,7 @@ source s_{{ .port_id }} {
         };
 {{ end }}
         rewrite(r_set_splunk_default);
-        {{ if eq (getenv "SC4S_USE_REVERSE_DNS" "yes") "yes" }}
+        {{ if eq (getenv "SC4S_USE_REVERSE_DNS" "no") "yes" }}
         if {
             filter(f_host_is_ip);
             parser(p_add_context_host);


### PR DESCRIPTION
* Change reverse DNS default to "no"
* Reverse DNS can cause unpredictable delay in both UDP and TCP event processing if a high-performance, caching nameserver is not used