### PR TITLE
Refine `SIMPLE` log path

### DIFF
--- a/docs/sources/Simple/index.md
+++ b/docs/sources/Simple/index.md
@@ -3,7 +3,7 @@
 ## Product - multiple
 
 The SIMPLE source configuration allows configuration of a log path for SC4S using a single port
-to a single index/sourcetype combintation to quickly onboard new sources that have not been formally
+to a single index/sourcetype combination to quickly onboard new sources that have not been formally
 supported in the product. Source data must use RFC5424 or a common variant of RFC3164 formatting.
 
 * NOTE:  This is an _interim_ step that should be used only to quickly onboard well-formatted data that is being sent over a
@@ -17,8 +17,8 @@ The keys (first column) in `splunk_metadata.csv` for SIMPLE data sources is a us
 For example, to on-board a new product `first firewall` using a source type of `first:firewall` and index `netfw`, add the following
 two lines to the configuration file as shown:
 ```
-simple_first_firewall,index,netfw
-simple_first_firewall,sourcetype,first:firewall
+first_firewall,index,netfw
+first_firewall,sourcetype,first:firewall
 ```
 
 ### Options
@@ -36,6 +36,14 @@ Based on the example above, to establish a tcp listener for `first firewall` we 
 
 ### Important Notes
 
-* Source data must use RFC5424 or a common variant of RFC3164 formatting.
-* the key(s) chosen for `splunk_metadata.csv` must be in the form `vendor_product` (lower case).
-* The environment variables must have a core of `VENDOR_PRODUCT` (upper case).
+* `SIMPLE` data sources must use RFC5424 or a common variant of RFC3164 formatting.
+* Each `SIMPLE` data source must listen on its own unique port list.  Port overlap with other
+sources, either `SIMPLE` ones or those served by regular log paths, are not allowed and will cause an error at startup.
+* The key(s) chosen for `splunk_metadata.csv` must be in the form `vendor_product` (lower case).
+* These same keys can be used for a regular SC4S log path developed in the future.
+* The `SIMPLE` environment variables must have a core of `VENDOR_PRODUCT` (upper case).
+* Take care to remove the `SIMPLE` form of these `LISTEN` variables after a regular SC4S log path is developed for
+a given source. You can, of course, continue to listen for this source on the same unique ports after having developed
+the new log path, but use the `SC4S_LISTEN_<VENDOR_PRODUCT>_<protocol>_PORT` form of the variable to ensure the newly
+developed log path will listen on the specified unique ports.
+

--- a/package/etc/conf.d/log_paths/lp-zzw-simple_port.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zzw-simple_port.conf.tmpl
@@ -2,13 +2,14 @@
 {{- range split (getenv "SOURCE_SIMPLE_SET" "") "," }}
 
 {{- /* The following provides a unique port source configuration if env var(s) are set */}}
-{{- $context := dict "port_id" (strings.ToUpper .) "parser" "common" }}
+{{- $context := dict "port_id" (print "SIMPLE_" (strings.ToUpper .)) "parser" "common" }}
 
 {{- tmpl.Exec "t/source_network.t" $context }}
 
 log {
+
 # Listen on the specified dedicated port(s) for {{ . }} traffic
-source (s_{{ (strings.ToUpper .) }});
+source (s_SIMPLE_{{ (strings.ToUpper .) }});
 
 # Set a default sourcetype and index, as well as an appropriate value for the field
 # "sc4s_vendor_product".  This field is sent as an indexed field to Splunk,

--- a/package/etc/context_templates/splunk_metadata.csv.example
+++ b/package/etc/context_templates/splunk_metadata.csv.example
@@ -155,5 +155,5 @@ zscaler_lss,index,netproxy
 zscaler_web,index,netproxy
 zscaler_zia_audit,index,netops
 zscaler_zia_sandbox,index,main
-simple_test_one,index,netops
-simple_test_one,sourcetype,sc4s:porttest
+test_one,index,netops
+test_one,sourcetype,sc4s:porttest

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -123,7 +123,7 @@ then
 fi
 
 # Create a workable variable with a list of simple log paths
-export SOURCE_SIMPLE_SET=$(printenv | grep '^SC4S_LISTEN_SIMPLE_.*_PORT' | sed 's/^SC4S_LISTEN_//;s/_..P_PORT\=.*//' |  xargs echo | sed 's/ /,/g' | tr '[:upper:]' '[:lower:]')
+export SOURCE_SIMPLE_SET=$(printenv | grep '^SC4S_LISTEN_SIMPLE_.*_PORT' | sed 's/^SC4S_LISTEN_SIMPLE_//;s/_..P_PORT\=.*//' |  xargs echo | sed 's/ /,/g' | tr '[:upper:]' '[:lower:]')
 
 # Run gomplate to create config from templates if the command errors this is fatal
 # Stop the container. Errors in this step should only happen with user provided


### PR DESCRIPTION
* Refine `SIMPLE` log path to follow traditional `vendor_product` syntax in all config areas