### PR TITLE
Update comment to reflect upper case

### DIFF
--- a/package/etc/conf.d/log_paths/lp-zzw-simple_port.conf.tmpl
+++ b/package/etc/conf.d/log_paths/lp-zzw-simple_port.conf.tmpl
@@ -8,7 +8,7 @@
 
 log {
 
-# Listen on the specified dedicated port(s) for {{ . }} traffic
+# Listen on the specified dedicated port(s) for {{ (strings.ToUpper .) }} traffic
 source (s_SIMPLE_{{ (strings.ToUpper .) }});
 
 # Set a default sourcetype and index, as well as an appropriate value for the field


### PR DESCRIPTION
* Update comment to reflect upper case variable name passed to `source_networks.t` and align with convention in regular log paths