### PR TITLE
fix: Correct issue with migrated location for syslog queue files

### DIFF
--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -81,12 +81,24 @@ then
   fi
 fi
 
+# Update the syslog-ng persist file for the new root directory ($SC4S_VAR) if necessary
+# Should only be required on first restart after upgrade to v1.43.0+
+# Routine can be removed at v2.0
+
+pushd $SC4S_VAR
+if [[ $(persist-tool dump syslog-ng.persist) =~ "2F 6F 70 74" ]]; then
+    persist-tool dump syslog-ng.persist > syslog-ng.persist.dump
+    sed -i "s/2F 6F 70 74 2F 73 79 73 6C 6F 67 2D 6E 67 2F 76 61 72/2F 76 61 72 2F 6C 69 62 2F 73 79 73 6C 6F 67 2D 6E 67/" syslog-ng.persist.dump
+    persist-tool add syslog-ng.persist.dump -o .
+    rm syslog-ng.persist.dump
+fi
+popd
+
 mkdir -p $SC4S_VAR/log/
 mkdir -p $SC4S_ETC/conf.d/local/context/
 mkdir -p $SC4S_ETC/conf.d/merged/context/
 mkdir -p $SC4S_ETC/conf.d/local/config/
 mkdir -p $SC4S_ETC/local_config/
-cd $SC4S_ETC
 
 cp -f $SC4S_ETC/context_templates/* $SC4S_ETC/conf.d/local/context
 for file in $SC4S_ETC/conf.d/local/context/*.example ; do cp --verbose -n $file ${file%.example}; done
@@ -148,10 +160,12 @@ export SOURCE_PLUGINS_NS=$(ls sp_ns_*.t -1p | xargs echo | sed 's/ /,/g')
 export SOURCE_PLUGINS_RFC3164=$(ls sp_rfc3164_*.t -1p | xargs echo | sed 's/ /,/g')
 popd
 
+pushd $SC4S_ETC
 if ! gomplate $(find . -name "*.tmpl" | sed -E 's/^(\/.*\/)*(.*)\..*$/--file=\2.tmpl --out=\2/') --template t=$SC4S_ETC/go_templates/; then
   echo "Error in Gomplate template; unable to continue, exiting..."
   exit 800
 fi
+popd
 
 # OPTIONAL for BYOE:  Comment out SNMP stanza immediately below and launch snmptrapd directly from systemd
 # Launch snmptrapd


### PR DESCRIPTION
* Add stanza to `entrypoint.sh` to check for a persist file that references the old root directory for the buffer queue files.  Update to new root if necessary.
* Move `cd $S4S_ETC` to the appropriate place (before gomplate execution)
* Update current directory handling (pushd/popd)