### PR TITLE
doc: Important Note to remind users to use the latest unit/compose file

### DIFF
--- a/docs/gettingstarted/docker-compose-MacOS.md
+++ b/docs/gettingstarted/docker-compose-MacOS.md
@@ -10,7 +10,12 @@ SC4S can be run with `docker-compose` or directly from the CLI with the simple `
 * Create a directory on the server for local configurations and disk buffering. This should be available to all administrators, for example:
 `/opt/sc4s/`
 
-* (Optional for `docker-compose`) Create a docker-compose.yml file in the directory created above, based on the following template:
+* (Optional for `docker-compose`) Create a docker-compose.yml file in the directory created above, based on the template below:
+
+* IMPORTANT:  Always use the _latest_ compose file (below) with the current release.  By default, the latest container is
+automatically downloaded at each restart.  Therefore, make it a habit to check back here regularly to be sure any changes
+that may have been made to the compose template file below (e.g. suggested mount points) are incoproprated in production
+prior to relaunching via compose.
 
 ```yaml
 version: "3.7"

--- a/docs/gettingstarted/docker-swarm-general.md
+++ b/docs/gettingstarted/docker-swarm-general.md
@@ -29,7 +29,12 @@ net.ipv4.ip_forward=1
 administrators, for example:
 `/opt/sc4s/`
 
-* Create a docker-compose.yml file in the directory created above, based on the following template:
+* Create a docker-compose.yml file in the directory created above, based on the template below:
+
+* IMPORTANT:  Always use the _latest_ compose file (below) with the current release.  By default, the latest container is
+automatically downloaded at each restart.  Therefore, make it a habit to check back here regularly to be sure any changes
+that may have been made to the compose template file below (e.g. suggested mount points) are incoproprated in production
+prior to relaunching via compose.
 
 ```yaml
 version: "3.7"

--- a/docs/gettingstarted/docker-swarm-rhel7.md
+++ b/docs/gettingstarted/docker-swarm-rhel7.md
@@ -37,7 +37,12 @@ sudo docker swarm init
 * Create a directory on the server for local configurations and disk buffering. This should be available to all administrators, for example:
 `/opt/sc4s/`
 
-* Create a docker-compose.yml file in the directory created above, based on the following template:
+* Create a docker-compose.yml file in the directory created above, based on the template below:
+
+* IMPORTANT:  Always use the _latest_ compose file (below) with the current release.  By default, the latest container is
+automatically downloaded at each restart.  Therefore, make it a habit to check back here regularly to be sure any changes
+that may have been made to the compose template file below (e.g. suggested mount points) are incoproprated in production
+prior to relaunching via compose.
 
 ```yaml
 version: "3.7"

--- a/docs/gettingstarted/docker-systemd-general.md
+++ b/docs/gettingstarted/docker-systemd-general.md
@@ -1,4 +1,3 @@
-
 # Install Docker CE
 
 Refer to relevant installation guides:
@@ -22,6 +21,11 @@ net.ipv4.ip_forward=1
 ```
 
 # Initial Setup
+
+* IMPORTANT:  Always use the _latest_ unit file (below) with the current release.  By default, the latest container is
+automatically downloaded at each restart.  Therefore, make it a habit to check back here regularly to be sure any changes
+that may have been made to the template unit file below (e.g. suggested mount points) are incoproprated in production prior
+to relaunching via systemd.
 
 * Create the systemd unit file `/lib/systemd/system/sc4s.service` based on the following template:
 


### PR DESCRIPTION
* Highlight via `IMPORTANT:` the need to always use the latest and greatest unit/compose file
* Remove obsolete `conntrack` workarround updates