### PR TITLE
doc:  Clarify `splunk_metadata.csv` operation; Alphabetize Cisco sources

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,28 +208,37 @@ included with all "out-of-the-box" log paths included with SC4S and are chosen t
 TA in Splunk.  The administrator will need to ensure all recommneded indexes be created to accept this data if the defaults
 are not changed.
 
-It is understood that default values will need to be changed in many installations. To accomodate this, each filter consults
-a lookup file that is mounted to the container (by default `/opt/sc4s/local/context/splunk_metadata.csv`) and is populated with
-defaults on the first run of SC4S after being set up according to the "getting started" runtime documents.  This is a CSV
+It will be common to override default values in many installations. To accomodate this, each log path consults
+an internal lookup file that maps Splunk metadata to the specific data source being processed.  This file contains the
+defaults that are used by SC4S to set the appropriate Splunk metadata (`index`, `host`, `source`, and `sourcetype`) for each
+data source.  This file is not directly available to the administrator, but a copy of the file is deposited in the local mouunted directory
+(by default `/opt/sc4s/local/context/splunk_metadata.csv.example`) for reference.  It is important to note that this copy is _not_ used
+directly, but is provided solely for reference.  To add to the list, or to override default entries, simply create an override file without
+the `example` extension (e.g. `/opt/sc4s/local/context/splunk_metadata.csv`) and modify it according to the instructions below.
+
+`splunk_metadata.csv` is a CSV
 file containing a "key" that is referenced in the log path for each data source.  These keys are documented in the individual
 source files in this section, and allow one to override Splunk metadata either in whole or part. The use of this file is best
-shown by example.  Here is the "Sourcetype and Index Configuration" table from the Juniper Netscreen source documentation
-page in this section:
+shown by example.  Here is the Netscreen "Sourcetype and Index Configuration" table from the Juniper
+[source documentation](sources/Juniper/index.md):
 
 | key                    | sourcetype          | index          | notes         |
 |------------------------|---------------------|----------------|---------------|
 | juniper_netscreen      | netscreen:firewall  | netfw          | none          |
 
-Here is a snippet from the `splunk_metadata.csv` file:
+Here is a line from a typical `splunk_metadata.csv` override file:
 
 ```bash
 juniper_netscreen,index,ns_index
 ```
 
-The columns in this file are `key`, `metadata`, and `value`.  Defaults are populated into this file at initial startup, and any changes
-made will be preserved on subsequent startups. Changes can be made by modifying and/or adding rows in the table and specifying one or more
-of the following `metadata`/`value` pairs for a given `key`:
+The columns in this file are `key`, `metadata`, and `value`.  To make a change via the override file, consult the `example` file (or
+the source documentation) for the proper key when overrdiing an existing source and modify and/or add rows in the table, specifying one or
+more of the following `metadata/value` pairs for a given `key`:
 
+   * `key` which refers to the vendor and product name of the data source, using the `vendor_product` convention.  For overrides, these keys
+   will be listed in the `example` file.  For new (custom) sources, be sure to choose a key that accurately reflects the vendor and product
+   being configured, and that matches what is specified in the log path.
    * `index` to specify an alternate `value` for index
    * `source` to specify an alternate `value` for source
    * `host` to specify an alternate `value` for host
@@ -237,18 +246,26 @@ of the following `metadata`/`value` pairs for a given `key`:
     TA is _not_ being used, or a custom TA (built by you) is being used.)
    * `sc4s_template` to specify an alternate `value` for the syslog-ng template that will be used to format the event that will be
    indexed by Splunk.  Changing this carries the same warning as the sourcetype above; this will affect the upstream TA.  The template
-   choices are documented elsewhere in this "Configuration" section.
+   choices are documented [elsewhere](configuration.md#splunk-connect-for-syslog-output-templates-syslog-ng-templates) in this Configuration section.
 
-In this case, the `juniper_netscreen` key references a new index used for that data source called `ns_index`.
+In our example above, the `juniper_netscreen` key references a new index used for that data source called `ns_index`.
 
 In general, for most deployments the index should be the only change needed; other default metadata should almost
 never be overridden (particularly for the "Out of the Box" data sources).  Even then, care should be taken when considering any alternates,
 as the defaults for SC4S were chosen with best practices in mind.
 
-The `splunk_metadata.csv` file should also be appended to with an appropriate default for the index when building a custom SC4S log path
-(filter).  Care should be taken during filter design to choose appropriate index, sourctype and template defaults, so that admins are not
-compelled to override them.
+* NOTE:  The `splunk_metadata.csv` file is a true override file and the entire `example` file should not be copied over to the
+override.  In most cases, the override file is just one or two lines, unless an entire index category (e.g. `netfw`) needs to be overridden.
+This is similar in concept to the "default" and "local" conf file precedence in Splunk Enterprise.
 
+* NOTE The `splunk_metadata.csv` file should always be appended with an appropriate new key and default for the index when building a custom
+SC4S log path, as the new key will not exist in the internal lookup (nor the `example` file).  Care should be taken during log path design to
+choose appropriate index, sourctype and template defaults so that admins are not compelled to override them.  If the custom log path is later
+added to the list of SC4S-supported sources, this addendum can be removed.
+
+* NOTE:  As noted above, the `splunk_metadata.csv.example` file is provided for reference only and is not used directly by SC4S.  However,
+it is an exact copy of the internal file, and can therefore change from release to release.  Be sure to check the example file first to make
+sure the keys for any overrides map correctly to the ones in the example file.
 
 ### Override index or metadata based on host, ip, or subnet (compliance overrides)
 

--- a/docs/sources/Cisco/index.md
+++ b/docs/sources/Cisco/index.md
@@ -1,6 +1,50 @@
 # Vendor - Cisco
 
-## Product - ACS
+## Product - Application Control Engine (ACE)
+
+| Ref            | Link                                                                                                    |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| Splunk Add-on  | None                                                               |
+
+### Sourcetypes
+
+| sourcetype     | notes                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| cisco:ace      | This source type is also used for ACE                                                                                                    |
+
+### Sourcetype and Index Configuration
+
+| key            | sourcetype     | index          | notes          |
+|----------------|----------------|----------------|----------------|
+| cisco_ace      | cisco:ace      | netops          | none          |
+
+### Filter type
+
+* Cisco ACE products can be identified by message parsing alone
+
+
+### Setup and Configuration
+
+Unknown this product is unsupported by Cisco
+
+### Options
+
+| Variable       | default        | description    |
+|----------------|----------------|----------------|
+| SC4S_LISTEN_CISCO_ACE_UDP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_LISTEN_CISCO_ACE_TCP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_ARCHIVE_CISCO_ACE | no | Enable archive to disk for this specific source |
+| SC4S_DEST_CISCO_ACE_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
+
+### Verification
+
+Use the following search to validate events are present
+
+```
+index=<asconfigured> sourcetype=cisco:ace | stats count by host
+```
+
+## Product - Cisco Access Control System (ACS)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -127,55 +171,64 @@ index=<asconfigured> sourcetype=cisco:asa
 
 Verify timestamp, and host values match as expected    
 
-## Product - Application Control Engine
-
-
-
+## Product - Cisco Email Security Appliance (ESA)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
-| Splunk Add-on  | None                                                               |
+| Splunk Add-on  | https://splunkbase.splunk.com/app/1761/                                                                |
+| Product Manual | https://www.cisco.com/c/en/us/td/docs/security/esa/esa13-5-1/user_guide/b_ESA_Admin_Guide_13-5-1.html |
 
 ### Sourcetypes
 
 | sourcetype     | notes                                                                                                   |
 |----------------|---------------------------------------------------------------------------------------------------------|
-| cisco:ace      | This source type is also used for ACE                                                                                                    |
+| cisco:esa:http     |  The HTTP logs of Cisco IronPort ESA record information about the secure HTTP services enabled on the interface.  |
+| cisco:esa:textmail     |  Text mail logs of Cisco IronPort ESA record email information and status.  |
+| cisco:esa:amp     |  Advanced Malware Protection (AMP) of Cisco IronPort ESA records malware detection and blocking, continuous analysis, and retrospective alerting details.   |
+| cisco:esa:authentication     |  These logs record successful user logins and unsuccessful login attempts.   |
+| cisco:esa:cef     |  The Consolidated Event Logs summarizes each message event in a single log line.  |
 
 ### Sourcetype and Index Configuration
 
 | key            | sourcetype     | index          | notes          |
 |----------------|----------------|----------------|----------------|
-| cisco_ace      | cisco:ace      | netops          | none          |
+| cisco_esa    | cisco:esa:http    | email          | None     |
+| cisco_esa    | cisco:esa:textmail    | email          | None     |
+| cisco_esa    | cisco:esa:amp    | email          | None     |
+| cisco_esa    | cisco:esa:authentication    | email          | None     |
+| cisco_esa    | cisco:esa:cef    | email          | None     |
 
 ### Filter type
 
-* Cisco ACE products can be identified by message parsing alone
-
+IP, Netmask or Host
 
 ### Setup and Configuration
 
-Unknown this product is unsupported by Cisco
+* Install the Splunk Add-on on the search head(s) for the user communities interested in this data source. If SC4S is exclusively used the addon is not required on the indexer.
+* ESA Follow vendor configuration steps per Product Manual.
+* Ensure host and timestamp are included.
+* Update ``vi /opt/sc4s/local/context/vendor_product_by_source.conf `` update the host or ip mask for ``f_cisco_esa`` to identiy the esa events.
 
 ### Options
 
 | Variable       | default        | description    |
 |----------------|----------------|----------------|
-| SC4S_LISTEN_CISCO_ACE_UDP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_LISTEN_CISCO_ACE_TCP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_ARCHIVE_CISCO_ACE | no | Enable archive to disk for this specific source |
-| SC4S_DEST_CISCO_ACE_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
+| SC4S_LISTEN_CISCO_ESA_TCP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_LISTEN_CISCO_ESA_UDP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_ARCHIVE_CISCO_ESA | no | Enable archive to disk for this specific source |
+| SC4S_DEST_CISCO_ESA_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
 
 ### Verification
 
 Use the following search to validate events are present
 
 ```
-index=<asconfigured> sourcetype=cisco:ace | stats count by host
+index=email sourcetype=cisco:esa:*
 ```
 
+Verify timestamp, and host values match as expected
 
-## Product - CIMC
+## Product - Cisco Integrated Management Controller (IMC)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -223,7 +276,7 @@ index=<asconfigured> sourcetype=cisco:cimc
 
 Verify timestamp, and host values match as expected
 
-## Product - Cisco Networking
+## Product - Cisco Networking (IOS and flavors)
 
 Cisco Network Products of multiple types share common logging characteristics the following types are known to be compatible:
 
@@ -304,7 +357,7 @@ Use the following search to validate events are present, for NX-OS, WLC and ACI 
 index=<asconfigured> sourcetype=cisco:ios | stats count by host
 ```
 
-## Product - ISE
+## Product - Cisco Identity Services Engine (ISE)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -352,7 +405,7 @@ index=<asconfigured> sourcetype=cisco:ise:syslog
 
 Verify timestamp, and host values match as expected    
 
-## Product - Meraki Product Line MR, MS, MX, MV
+## Product - Meraki Product Line (MR, MS, MX, MV)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -451,7 +504,7 @@ index=<asconfigured> sourcetype=cisco:ucm
 Verify timestamp, and host values match as expected
 
 
-## Product - UCS
+## Product - Cisco Unified Computing System (UCS)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -499,7 +552,55 @@ index=<asconfigured> sourcetype=cisco:ucs
 
 Verify timestamp, and host values match as expected
 
-## Product - WSA
+## Product - Cisco UCS Hyperflex
+
+| Ref            | Link                                                                                                    |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| Splunk Add-on  | na                                                               |
+| Product Manual | multiple |
+
+
+### Sourcetypes
+
+| sourcetype     | notes                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| cisco:ucs:hx    |  None                                                                                                    |
+
+### Sourcetype and Index Configuration
+
+| key            | sourcetype     | index          | notes          |
+|----------------|----------------|----------------|----------------|
+| cisco_ucs_hx    | cisco:ucs:hx    | main          | None     |
+
+
+### Filter type
+
+PATTERN MATCH
+
+### Setup and Configuration
+
+* Refer to Cisco support web site
+
+### Options
+
+| Variable       | default        | description    |
+|----------------|----------------|----------------|
+| SC4S_LISTEN_CISCO_UCS_HX_TCP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_LISTEN_CISCO_UCS_HX_UDP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
+| SC4S_ARCHIVE_CISCO_UCS_HX | no | Enable archive to disk for this specific source |
+| SC4S_DEST_CISCO_UCS_HX_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
+
+### Verification
+
+Use the following search to validate events are present
+
+```
+index=<asconfigured> sourcetype=cisco:ucs:hx
+```
+
+Verify timestamp, and host values match as expected
+
+## Product - Cisco Web Security Appliance (WSA)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|
@@ -550,112 +651,6 @@ Use the following search to validate events are present
 
 ```
 index=netops sourcetype=cisco:wsa:*
-```
-
-Verify timestamp, and host values match as expected
-
-
-## Product - ESA
-
-| Ref            | Link                                                                                                    |
-|----------------|---------------------------------------------------------------------------------------------------------|
-| Splunk Add-on  | https://splunkbase.splunk.com/app/1761/                                                                |
-| Product Manual | https://www.cisco.com/c/en/us/td/docs/security/esa/esa13-5-1/user_guide/b_ESA_Admin_Guide_13-5-1.html |
-
-### Sourcetypes
-
-| sourcetype     | notes                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------|
-| cisco:esa:http     |  The HTTP logs of Cisco IronPort ESA record information about the secure HTTP services enabled on the interface.  |
-| cisco:esa:textmail     |  Text mail logs of Cisco IronPort ESA record email information and status.  |
-| cisco:esa:amp     |  Advanced Malware Protection (AMP) of Cisco IronPort ESA records malware detection and blocking, continuous analysis, and retrospective alerting details.   |
-| cisco:esa:authentication     |  These logs record successful user logins and unsuccessful login attempts.   |
-| cisco:esa:cef     |  The Consolidated Event Logs summarizes each message event in a single log line.  |
-
-### Sourcetype and Index Configuration
-
-| key            | sourcetype     | index          | notes          |
-|----------------|----------------|----------------|----------------|
-| cisco_esa    | cisco:esa:http    | email          | None     |
-| cisco_esa    | cisco:esa:textmail    | email          | None     |
-| cisco_esa    | cisco:esa:amp    | email          | None     |
-| cisco_esa    | cisco:esa:authentication    | email          | None     |
-| cisco_esa    | cisco:esa:cef    | email          | None     |
-
-### Filter type
-
-IP, Netmask or Host
-
-### Setup and Configuration
-
-* Install the Splunk Add-on on the search head(s) for the user communities interested in this data source. If SC4S is exclusively used the addon is not required on the indexer.
-* ESA Follow vendor configuration steps per Product Manual.
-* Ensure host and timestamp are included.
-* Update ``vi /opt/sc4s/local/context/vendor_product_by_source.conf `` update the host or ip mask for ``f_cisco_esa`` to identiy the esa events.
-
-### Options
-
-| Variable       | default        | description    |
-|----------------|----------------|----------------|
-| SC4S_LISTEN_CISCO_ESA_TCP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_LISTEN_CISCO_ESA_UDP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_ARCHIVE_CISCO_ESA | no | Enable archive to disk for this specific source |
-| SC4S_DEST_CISCO_ESA_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
-
-### Verification
-
-Use the following search to validate events are present
-
-```
-index=email sourcetype=cisco:esa:*
-```
-
-Verify timestamp, and host values match as expected
-
-## Product - UCS-Hyperflex
-
-| Ref            | Link                                                                                                    |
-|----------------|---------------------------------------------------------------------------------------------------------|
-| Splunk Add-on  | na                                                               |
-| Product Manual | multiple |
-
-
-### Sourcetypes
-
-| sourcetype     | notes                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------|
-| cisco:ucs:hx    |  None                                                                                                    |
-
-### Sourcetype and Index Configuration
-
-| key            | sourcetype     | index          | notes          |
-|----------------|----------------|----------------|----------------|
-| cisco_ucs_hx    | cisco:ucs:hx    | main          | None     |
-
-
-### Filter type
-
-PATTERN MATCH
-
-### Setup and Configuration
-
-* Refer to Cisco support web site
-
-### Options
-
-| Variable       | default        | description    |
-|----------------|----------------|----------------|
-| SC4S_LISTEN_CISCO_UCS_HX_TCP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_LISTEN_CISCO_UCS_HX_UDP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
-| SC4S_ARCHIVE_CISCO_UCS_HX | no | Enable archive to disk for this specific source |
-| SC4S_DEST_CISCO_UCS_HX_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
-
-### Verification
-
-Use the following search to validate events are present
-
-```
-index=<asconfigured> sourcetype=cisco:ucs:hx
 ```
 
 Verify timestamp, and host values match as expected

--- a/docs/sources/Cisco/index.md
+++ b/docs/sources/Cisco/index.md
@@ -455,7 +455,7 @@ index=<asconfigured> sourcetype=merkai
 
 Verify timestamp, and host values match as expected    
 
-## Product - UCM
+## Product - Cisco Unified Communications Manager (UCM)
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
* Clarify override operation of `splunk_metadata.csv` and role of `splunk_metadata.csv.example`
* Alphebetize Cisco sources in source doc and expand acronyms