### PR TITLE
fix(cisco_ucm): Search and replace causes invalid log path

### DIFF
--- a/package/etc/conf.d/log_paths/1/lp-cisco_ucm.conf.tmpl
+++ b/package/etc/conf.d/log_paths/1/lp-cisco_ucm.conf.tmpl
@@ -52,7 +52,7 @@ log {
 
     if (filter({{ print (getenv "SC4S_DEST_CISCO_UCM_ALT_FILTER") }})) {
 {{- if (print (getenv "SC4S_DEST_CISCO_UCM_FILTERED_ALTERNATES")) }}
-        {{ getenv "SC4S_DEST_CISCO_UCM_FILTERED_ALTERNATES" | regexp.ReplucmLiteral "^" "destination(" | regexp.ReplucmLiteral "[, ]+" ");\n        destination(" }});
+        {{ getenv "SC4S_DEST_CISCO_UCM_FILTERED_ALTERNATES" | regexp.ReplaceLiteral "^" "destination(" | regexp.ReplaceLiteral "[, ]+" ");\n        destination(" }});
 {{- end }}
     }
     else {
@@ -72,13 +72,13 @@ log {
 {{- /* Check environment variables for sending to a global list of alternate destinations */}}
 
 {{- if (print (getenv "SC4S_DEST_GLOBAL_ALTERNATES")) }}
-    {{ getenv "SC4S_DEST_GLOBAL_ALTERNATES" | regexp.ReplucmLiteral "^" "destination(" | regexp.ReplucmLiteral "[, ]+" ");\n    destination(" }});
+    {{ getenv "SC4S_DEST_GLOBAL_ALTERNATES" | regexp.ReplaceLiteral "^" "destination(" | regexp.ReplaceLiteral "[, ]+" ");\n    destination(" }});
 {{- end }}
 
 {{- /* Check environment variables for sending to a list of alternate destinations only for this specific source */}}
 
 {{- if (print (getenv "SC4S_DEST_CISCO_UCM_ALTERNATES")) }}
-    {{ getenv "SC4S_DEST_CISCO_UCM_ALTERNATES" | regexp.ReplucmLiteral "^" "destination(" | regexp.ReplucmLiteral "[, ]+" ");\n    destination(" }});
+    {{ getenv "SC4S_DEST_CISCO_UCM_ALTERNATES" | regexp.ReplaceLiteral "^" "destination(" | regexp.ReplaceLiteral "[, ]+" ");\n    destination(" }});
 {{- end }}
 
 {{- if (print (getenv "SC4S_DEST_CISCO_UCM_ALT_FILTER")) }}


### PR DESCRIPTION
Resolve this error at startup when an alt dest is enabled
"./conf.d/log_paths/1/lp-cisco_ucm.conf.tmpl" at <regexp>: can't evaluate field ReplucmLiteral in type *funcs.ReFuncs