### PR TITLE
fix(source): Safer detection of malformed BSD Syslog versioned

### DIFF
--- a/package/etc/conf.d/conflib/_common/syslog_format.conf
+++ b/package/etc/conf.d/conflib/_common/syslog_format.conf
@@ -26,7 +26,10 @@ rewrite set_rfc3164_epoch{
     set("rfc3164_epoch" value("fields.sc4s_syslog_format"));
 };
 rewrite set_rfc3164{
-    set("rfc3164" value("fields.sc4s_syslog_format"));
+    set("rfc3164" 
+        value("fields.sc4s_syslog_format")
+        condition("${fields.sc4s_syslog_format}" eq "")
+     );
 };
 filter f_is_rfc3164{
     match("rfc3164" value("fields.sc4s_syslog_format"))

--- a/package/etc/conf.d/log_paths/2/lp-juniper_junos.conf.tmpl
+++ b/package/etc/conf.d/log_paths/2/lp-juniper_junos.conf.tmpl
@@ -16,7 +16,6 @@ log {
         channel {
         # Listen on the default port (typically 514) for JUNIPER_JUNOS traffic
             source (s_DEFAULT);
-            filter(f_is_rfc3164);
             filter(f_juniper_junos_standard);
             flags(final);
         };

--- a/package/etc/patterndb-raw.d/syslog.xml
+++ b/package/etc/patterndb-raw.d/syslog.xml
@@ -36,10 +36,10 @@
                     <value name="fields.sc4s_syslog_format">rfc5424_strict</value>
                 </values>
             </rule>
-            <rule provider='rfc' id='raw_rfc3684_versioned' class='splunk'>
+            <rule provider='rfc' id='raw_rfc3164_versioned' class='splunk'>
 
                 <patterns>
-                    <pattern>@QSTRING:PRI:&lt;&gt;@1 @SET:.raw.MONTH:JFMANDO@@ESTRING:.raw.MONTH2: @@ANYSTRING:.raw.message@</pattern>
+                    <pattern>@QSTRING:PRI:&lt;&gt;@1 @SET:.raw.MONTH:JFMANDO@@PCRE:.raw.MONTH2:[a-z]{2}@ @ANYSTRING:.raw.message@</pattern>
                 </patterns>
                 <examples>
                     <example>
@@ -48,9 +48,10 @@
                 </examples>
                 <values>
                     <value name="MESSAGE">&lt;${PRI}&gt; ${.raw.MONTH}${.raw.MONTH2} ${.raw.message}</value>
+                    <value name="fields.sc4s_syslog_format">rfc_3164_version</value>
                 </values>
             </rule>
-            <rule provider='rfc' id='raw_rfc3684_epoch' class='splunk'>
+            <rule provider='rfc' id='raw_rfc3164_epoch' class='splunk'>
 
                 <patterns>
                     <pattern>@QSTRING:PRI:&lt;&gt;@ @NUMBER:EPOCH@ @ESTRING:HOST: @@ANYSTRING:MESSAGE@</pattern>
@@ -78,7 +79,7 @@
                 </values>
 
             </rule>
-            <rule provider='rfc' id='raw_rfc3684_json' class='splunk'>
+            <rule provider='rfc' id='raw_rfc3164_json' class='splunk'>
 
                 <patterns>
                     <pattern>@QSTRING:PRI:&lt;&gt;@{@ANYSTRING:.raw.message@</pattern>

--- a/package/etc/patterndb.d/juniper/junos.xml
+++ b/package/etc/patterndb.d/juniper/junos.xml
@@ -165,7 +165,7 @@
                 </tags>
                 <values>
                     <value name="fields.sc4s_vendor_product">juniper_junos</value>
-                    <value name="MESSAGE">${PROGRAM} ${MESSAGE}</value>
+                    <value name="MESSAGE">${PROGRAM}: ${MESSAGE}</value>
                     <value name="PROGRAM"></value>
                 </values>
             </rule>


### PR DESCRIPTION
When a 1 version indicator is present on a non 5424 event we strip the 1 to allow the parser to function correctly. Safer handling.