### PR TITLE
feat: When a syslog event fails to parse use new sourcetype

### DIFF
--- a/package/etc/conf.d/log_paths/1/lp-aab-syslog-ng_failed-parser.conf.tmpl
+++ b/package/etc/conf.d/log_paths/1/lp-aab-syslog-ng_failed-parser.conf.tmpl
@@ -1,0 +1,24 @@
+# This log path functions to black hole by IP allowing rogue sources such as 
+# vulnerability scanners to be ignored
+
+filter f_syslog_ng_rejected {
+    "${.classifier.rule_id}" eq "syslogng_error"
+};
+
+log {
+    
+    filter(f_syslog_ng_rejected);
+    rewrite(r_set_splunk_default);
+    rewrite { r_set_splunk_dest_default(sourcetype("sc4s:failed:parser")); };
+    parser { p_add_context_splunk(key("sc4s_fallback")); };
+    parser (compliance_meta_by_source);
+    rewrite { set("$(template ${.splunk.sc4s_template} $(template t_JSON_5424))" value("MSG")); };
+
+{{- if or (conv.ToBool (getenv "SC4S_DEST_SPLUNK_HEC_GLOBAL" "yes")) (conv.ToBool (getenv "SC4S_DEST_FALLBACK_HEC" "no")) }}
+    destination(d_hec);
+{{- end}}
+
+
+    flags(catchall,final);
+    
+};

--- a/package/etc/patterndb.d/syslog-ng.xml
+++ b/package/etc/patterndb.d/syslog-ng.xml
@@ -9,6 +9,7 @@
                 <tags>
                     <tag>log_path_known</tag>
                     <tag>syslog-ng</tag>
+                    <tag>syslog-ng_badmessage</tag>
                 </tags>
                 <values>
                     <value name="fields.sc4s_vendor_product">syslog-ng_fallback</value>


### PR DESCRIPTION
With certain poor implementation of RFC5424 by source vendors a message may fail to parse with a specific reason rendering the message non-processable. When this occurs uses sourcetype=sc4s:failed as the only solution for these events is a vendor fix.

![image](https://user-images.githubusercontent.com/35384120/108890242-550af080-75db-11eb-9894-509c54d35c00.png)
