### PR TITLE
fix(cisco_syslog): Parse PRI for cisco events

### DIFF
--- a/package/etc/conf.d/conflib/raw/app-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/raw/app-cisco_syslog.conf
@@ -18,6 +18,12 @@ parser cisco-parser-ex{
             filter(f_cisco_parse_host);
         };
         if {
+            parser {
+                syslog-parser(
+
+                    flags(assume-utf8, no-parse, store-raw-message)                    
+                );
+            };
             filter(f_cisco_parse_date);
             if {
                 filter {
@@ -49,6 +55,12 @@ parser cisco-parser-ex{
                 unset(value("6"));
             };
         } elif {
+            parser {
+                syslog-parser(
+
+                    flags(assume-utf8, no-parse, store-raw-message)                    
+                );
+            };
             filter {
                 match(
                     '(?<=: )(\d\d:\d\d:\d\d|\d+ \d)'


### PR DESCRIPTION
In most cases the cisco PRI is meaningless in some newer devices the severity will match the message using the new syslog-ng no parse feature to capture pri