### PR TITLE
feat(mark): Null queue messages that are marks

### DIFF
--- a/docs/sources/Splunk/index.md
+++ b/docs/sources/Splunk/index.md
@@ -38,6 +38,7 @@ section below for details.
 | Variable                          | default   | description    |
 |-----------------------------------|-----------|----------------|
 | SC4S_DEST_SPLUNK_SC4S_METRICS_HEC | event        | `event` produce metrics as plain text events; `single` produce metrics using Splunk Enterprise 7.3 single metrics format; `multi` produce metrics using Splunk Enterprise 8.x multi metric format |
+| SC4S_SOURCE_MARK_MESSAGE_NULLQUEUE | yes | (yes|no) null_queue messages with the body of -- MARK -- |
 
 ### Verification
 

--- a/package/etc/conf.d/conflib/fallback/app-nix_syslog.conf
+++ b/package/etc/conf.d/conflib/fallback/app-nix_syslog.conf
@@ -20,11 +20,12 @@ block parser nix_syslog_fallback-parser() {
 };
 application nix_syslog_fallback[fallback] {
 	filter { 
-        filter(f_is_rfc5424_strict);
+        (filter(f_is_rfc5424_strict);
         or (
             filter(f_is_rfc3164) and "${PROGRAM}" ne ""
             #and program('^[A-Za-z\-_]+$' )
-        )
+        ))
+        and "${fields.sc4s_vendor_product}" eq ""
     };	
     parser { nix_syslog_fallback-parser(); };   
 };

--- a/package/etc/conf.d/conflib/raw/app-f5_bigip_syslog.conf
+++ b/package/etc/conf.d/conflib/raw/app-f5_bigip_syslog.conf
@@ -15,10 +15,32 @@ block parser f5_bigip_syslog-parser() {
                 );
 
         };
+        if {
+            # If program is probably not valid cleanup MESSAGE so log paths don't have too
+            # This isn't great for performance but is reliable good reason to use 5424
+            filter{
+                "${MSGHDR}" ne "${LEGACY_MSGHDR}"
+                or not program('^[a-zA-Z0-9-_\/\(\)]+$')
+                or program('--')
+            };
+            rewrite {
+                set("$(template t_hdr_msg)" value("MSG"));
+                unset(value("LEGACY_MSGHDR"));
+                unset(value("PID"));                
+                unset(value("PROGRAM"));                
+            };                    
+             
+        };
         rewrite {
             set("f5_bigip", value("fields.sc4s_syslog_format"));
         };                       
-
+        rewrite {
+            r_set_splunk_dest_update(
+                vendor_product('null_queue')
+                condition("`SC4S_SOURCE_MARK_MESSAGE_NULLQUEUE`" ne "no" and message('-- MARK --'))
+            );
+        };
+         
    };
 };
 application f5_bigip_syslog[sc4s-raw-syslog] {

--- a/package/etc/conf.d/conflib/syslog/app-f5_bigip.conf
+++ b/package/etc/conf.d/conflib/syslog/app-f5_bigip.conf
@@ -57,19 +57,22 @@ block parser f5_bigip-parser() {
 };
 application f5_bigip[sc4s-syslog] {
 	filter { 
-        "${fields.sc4s_syslog_format}" eq "f5_bigip"              
-        or (    
-            (
-                program('iControlPortal.cgi' type(string) flags(prefix))
-                or program('tmsh' type(string) flags(prefix))
-                or program('mcpd' type(string) flags(prefix))
-                or program('mprov' type(string) flags(prefix))
-                or program('apmd' type(string) flags(prefix))
-                or program('tmm' type(string) flags(prefix))
-                or (program('F5' type(string) flags(prefix)) and not match('access_json' value('MSGID')))
+        (
+            "${fields.sc4s_syslog_format}" eq "f5_bigip"                      
+            or (    
+                (
+                    program('iControlPortal.cgi' type(string) flags(prefix))
+                    or program('tmsh' type(string) flags(prefix))
+                    or program('mcpd' type(string) flags(prefix))
+                    or program('mprov' type(string) flags(prefix))
+                    or program('apmd' type(string) flags(prefix))
+                    or program('tmm' type(string) flags(prefix))
+                    or (program('F5' type(string) flags(prefix)) and not match('access_json' value('MSGID')))
+                )
+                and not match('^\[F5@12276' value("SDATA"))
             )
-            and not match('^\[F5@12276' value("SDATA"))
         )
+        and "${fields.sc4s_vendor_product}" eq ""        
         ;
     };	
     parser { f5_bigip-parser(); };   

--- a/package/etc/conf.d/conflib/syslog/app-mark.conf
+++ b/package/etc/conf.d/conflib/syslog/app-mark.conf
@@ -1,0 +1,28 @@
+
+block parser mark_message-parser() {    
+ channel {
+        rewrite {
+            r_set_splunk_dest_default(
+                index("main")
+                sourcetype('sc4s:remote_mark')
+                vendor_product("sc4s_events")
+            );             
+        };       
+    
+        rewrite {
+            r_set_splunk_dest_update(
+                vendor_product('null_queue')
+                condition("`SC4S_SOURCE_MARK_MESSAGE_NULLQUEUE`" ne "no")
+            );
+        };    
+
+   };
+};
+application mark_message[sc4s-syslog] {
+	filter { 
+        message('-- MARK --$')
+        ;
+    };	
+    parser { mark_message-parser(); };   
+};
+

--- a/package/etc/go_templates/source_network.t
+++ b/package/etc/go_templates/source_network.t
@@ -123,8 +123,9 @@ source s_{{ .port_id }} {
                 # If program is probably not valid cleanup MESSAGE so log paths don't have too
                 # This isn't great for performance but is reliable good reason to use 5424
                 filter{
-                    "${MSGHDR}" ne "${LEGACY_MSGHDR}" or 
-                    not program('^[a-zA-Z0-9-_\/\(\)]+$')
+                    "${MSGHDR}" ne "${LEGACY_MSGHDR}"
+                    or not program('^[a-zA-Z0-9-_\/\(\)]+$')
+                    or program('--')
                 };
                 rewrite {
                     set("$(template t_hdr_msg)" value("MSG"));


### PR DESCRIPTION
Some syslog sources send -- MARK -- events these mean nearly nothing null_queue by default user can set "SC4S_SOURCE_MARK_MESSAGE_NULLQUEUE" to no to retain these events