### PR TITLE
fix: Updated sc4s filter to fix incorrect souretype assignment issue

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-symantec_ep.conf
+++ b/package/etc/conf.d/conflib/syslog/app-symantec_ep.conf
@@ -101,7 +101,7 @@ block parser symantec_ep-parser() {
             };
         } elif {
             filter {
-                message('(?:,The\smanagement\sserver|,The\sclient)')
+                message('(?:,The\smanagement\sserver|,The\sclient|issued Command)')
             };
             rewrite {
                 r_set_splunk_dest_update(


### PR DESCRIPTION
As part of this jira fixed below issue.
Below events is getting assigned into incorrect sourcetype

2021-03-23 04:17:01,Site: My Site,Server Name: C2560767323,Domain Name: Default,Client has downloaded the issued Command,WORKGROUP,Administrator,LocalComputer
Actual Result:
     sourcetype=symantec:ep:scm:system:syslog

Expected Result:
     sourcetype=symantec:ep:agent:syslog
     
After this change sourcetype will assign as expected result.

Jira Ref: [ADDON-35667](https://jira.splunk.com/browse/ADDON-35667)