### PR TITLE
fix(cisco_ftd): Support cisco FTD 6.6.1

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-cisco_syslog_nix.conf
+++ b/package/etc/conf.d/conflib/syslog/app-cisco_syslog_nix.conf
@@ -1,7 +1,7 @@
-block parser cisco_syslog_bsd-parser() {    
+block parser cisco_syslog_nix-parser() {    
  channel {
         filter {
-            message(
+            program(
                 '^%(.+)-([0-7])-([^\: ]+)'
                 flags(store-matches)
             )
@@ -11,6 +11,8 @@ block parser cisco_syslog_bsd-parser() {
             set("$2" value(".cisco.facility"));
             set("$3" value(".cisco.severity"));
             set("$4" value(".cisco.mnemonic"));
+            set("$MSGHDR$MESSAGE" value('MESSAGE'));
+            unset(value('PROGRAM'));
         };
         rewrite {
             r_set_splunk_dest_default(
@@ -26,11 +28,11 @@ block parser cisco_syslog_bsd-parser() {
 
    };
 };
-application cisco_syslog_bsd[sc4s-syslog] {
+application cisco_syslog_nix[sc4s-syslog] {
 	filter { 
         "${fields.sc4s_vendor_product}" eq ""
-        and message('%' type(string) flags(prefix));
+        and program('%' type(string) flags(prefix));
     };	
-    parser { cisco_syslog_bsd-parser(); };   
+    parser { cisco_syslog_nix-parser(); };   
 };
 

--- a/tests/test_cisco_asa.py
+++ b/tests/test_cisco_asa.py
@@ -162,7 +162,7 @@ def test_cisco_ftd(record_property, setup_wordlist, setup_splunk, setup_sc4s):
     epoch = epoch[:-7]
 
     mt = env.from_string(
-        "{{ mark }} {{ iso }}Z {{ host }} : %FTD-6-430003: DeviceUUID: 90e14378-2081-11e8-a7fa-d34972ba379f, AccessControlRuleAction: Allow, SrcIP: 75.150.94.75, DstIP: 172.30.0.2, SrcPort: 59698, DstPort: 8027, Protocol: tcp, IngressInterface: Outside2, EgressInterface: DMZ, IngressZone: Outside, EgressZone: DMZ, ACPolicy: Rapid7 5525X, AccessControlRuleName: Allow MDM - Out to DMZ, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, ConnectionDuration: 600, InitiatorPackets: 0, ResponderPackets: 0, InitiatorBytes: 31, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity\n"
+        "{{ mark }}{{ iso }}Z {{ host }} : %FTD-6-430003: DeviceUUID: 90e14378-2081-11e8-a7fa-d34972ba379f, AccessControlRuleAction: Allow, SrcIP: 75.150.94.75, DstIP: 172.30.0.2, SrcPort: 59698, DstPort: 8027, Protocol: tcp, IngressInterface: Outside2, EgressInterface: DMZ, IngressZone: Outside, EgressZone: DMZ, ACPolicy: Rapid7 5525X, AccessControlRuleName: Allow MDM - Out to DMZ, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, ConnectionDuration: 600, InitiatorPackets: 0, ResponderPackets: 0, InitiatorBytes: 31, ResponderBytes: 0, NAPPolicy: Balanced Security and Connectivity\n"
     )
     message = mt.render(mark="<166>", iso=iso, epoch=epoch, host=host)
 


### PR DESCRIPTION
Cisco FTD 6.1.1 removes " : " before %FTD and replaces with a double space. This makes the format "less" malformed and allowed it to pass as nix:syslog