### PR TITLE
fix(xml): When source is XML like but invalid don't stdout error

### DIFF
--- a/package/etc/conf.d/conflib/raw/app-syslog_xml.conf
+++ b/package/etc/conf.d/conflib/raw/app-syslog_xml.conf
@@ -10,6 +10,7 @@ block parser syslog_xml-parser() {
             xml(
                 prefix('.xml.')
                 template('$1')
+                drop-invalid(yes)
             );            
         };
     

--- a/package/etc/conf.d/sources/internal.conf
+++ b/package/etc/conf.d/sources/internal.conf
@@ -67,6 +67,7 @@ source s_internal {
                         match("Input is valid utf8, but the log message is not tagged as such," value("MESSAGE"))
                         or match("Syslog connection closed; fd=" value("MESSAGE"))
                         or match("Syslog connection accepted; fd=" value("MESSAGE"))                    
+                        or match("xml-parser failed; " value("MESSAGE"))                    
                     )
                 ) 
             };


### PR DESCRIPTION
Code was correctly sending event to fallback but also logging 1 error per event to stdout