### PR TITLE
fix(cisco_ftd): When cisco FTD wrong source type

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-cisco_syslog_bsd.conf
+++ b/package/etc/conf.d/conflib/syslog/app-cisco_syslog_bsd.conf
@@ -2,7 +2,7 @@ block parser cisco_syslog_bsd-parser() {
  channel {
         filter {
             match(
-                '^(%(.+)-([0-7])-([^\: ]+))([: ]) (.*)'
+                '^(%(.+)-([0-7])-([^\: ]+))([: ]) ?(.*)'
                 flags(store-matches)
                 value("MESSAGE")
             )

--- a/package/etc/conf.d/conflib/syslog/app-cisco_syslog_bsd.conf
+++ b/package/etc/conf.d/conflib/syslog/app-cisco_syslog_bsd.conf
@@ -1,9 +1,10 @@
 block parser cisco_syslog_bsd-parser() {    
  channel {
         filter {
-            message(
-                '^%(.+)-([0-7])-([^\: ]+)'
+            match(
+                '^(%(.+)-([0-7])-([^\: ]+))([: ]) (.*)'
                 flags(store-matches)
+                value("MESSAGE")
             )
         };
         rewrite {
@@ -11,6 +12,8 @@ block parser cisco_syslog_bsd-parser() {
             set("$2" value(".cisco.facility"));
             set("$3" value(".cisco.severity"));
             set("$4" value(".cisco.mnemonic"));
+            set("$5" value(".cisco.seperator"));
+            set("$6" value(".cisco.message"));
         };
         rewrite {
             r_set_splunk_dest_default(


### PR DESCRIPTION
When cisco FTD is sending mostly compliance (RFC3164) syslog instead of the normally broken cisco_syslog the source type is wrong for IDS events