### PR TITLE
feat: allow meta config for nix_syslog by more specific values

### DIFF
--- a/package/etc/conf.d/conflib/net_source/app-nix_syslog.conf
+++ b/package/etc/conf.d/conflib/net_source/app-nix_syslog.conf
@@ -13,6 +13,12 @@ block parser nix_syslog-parser() {
         };       
 
 
+        rewrite {
+            r_set_splunk_dest_update(
+                        meta_key('${.netsource.sc4s_vendor_product}_nix_syslog')
+                        
+            );
+        };
    };
 };
 application nix_syslog[sc4s-network-source] {


### PR DESCRIPTION
When a product key is arrived via vendor_product_by_source OR by PORT for example vmware_vsphere some data may still be "nix" like syslog. We will now compose a new product key ${.netsource.sc4s_vendor_product}_nix_syslog i.e. vmware_vsphere_nix_syslog allowing index/sourcetype to be overridden in this case. fixes #1176