### PR TITLE
feat(source): Support custom topic sets for extreme snowflakes

### DIFF
--- a/package/etc/conf.d/sc4slib/source_syslog/plugin.jinja
+++ b/package/etc/conf.d/sc4slib/source_syslog/plugin.jinja
@@ -84,9 +84,10 @@ source s_{{ port_id }} {
 
         rewrite(r_set_splunk_default);
     
+        
         if {
             parser { 
-                app-parser(topic(sc4s-raw-syslog)); 
+                app-parser(topic({{ topic }}-raw-syslog)); 
             };        
         } elif {
             filter{
@@ -117,9 +118,10 @@ source s_{{ port_id }} {
 
         if {
             parser { 
-                app-parser(topic(sc4s-syslog)); 
+                app-parser(topic({{ topic }}-syslog)); 
             };
-        };                
+        };
+        
 
         if {
             parser(p_add_context_host);
@@ -137,7 +139,7 @@ source s_{{ port_id }} {
         parser(vendor_product_by_source);
         if {
             parser { 
-                app-parser(topic(sc4s-network-source)); 
+                app-parser(topic({{ topic }}-network-source)); 
             };
         };
         
@@ -257,7 +259,7 @@ source s_{{ port_id }} {
         };
         if {
             parser { 
-                app-parser(topic(sc4s-syslog)); 
+                app-parser(topic({{ topic }}-syslog)); 
             };
         };        
         
@@ -275,7 +277,7 @@ source s_{{ port_id }} {
         parser(vendor_product_by_source);
         if {
             parser { 
-                app-parser(topic(sc4s-network-source)); 
+                app-parser(topic({{ topic }}-network-source)); 
             };
         };
 

--- a/package/etc/conf.d/sc4slib/source_syslog/plugin.py
+++ b/package/etc/conf.d/sc4slib/source_syslog/plugin.py
@@ -63,6 +63,7 @@ for port_id in ports.split(","):
         use_reverse_dns=use_reverse_dns,
         use_tls=use_tls,
         tls_dir=os.getenv(f"SC4S_TLS", 17039360),
+        topic=os.getenv(f"SC4S_LISTEN_{ port_id }_TOPIC", "sc4s"),
         port_udp=os.getenv(f"SC4S_LISTEN_{ port_id }_UDP_PORT", "disabled").split(","),
         port_udp_sockets=int(os.getenv(f"SC4S_SOURCE_LISTEN_UDP_SOCKETS", 4)),
         port_udp_sorecvbuff=os.getenv(f"SC4S_SOURCE_UDP_SO_RCVBUFF", 17039360),


### PR DESCRIPTION
fixes #1189

Adds support for a new env var by port id. When addressing noncompliant syslog sources there can be cases where the raw parser required may conflict with a supported raw parser. This feature allows the creation of app-parsers using a custom topic name.
```
SC4S_LISTEN_SIMPLE_FIRST_FIREWALL_UDP=9998
SC4S_LISTEN_SIMPLE_FIRST_FIREWALL_TOPIC=mytopic
```
will produce
```
app-parser(topic(mytopic-raw-syslog)); 
```