### PR TITLE
fix(cisco_syslog): support IOS with extra space in header

### DIFF
--- a/package/etc/conf.d/conflib/raw/app-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/raw/app-cisco_syslog.conf
@@ -84,7 +84,7 @@ block parser cisco_syslog-parser() {
 
         filter {
             match(
-                '^(%(.+)-([0-7])-([^\: ]+))([: ]) (.*)'
+                '^(%(.+)-([0-7])-([^\: ]+))( ?[: ]) (.*)'
                 flags(store-matches)
                 value("MESSAGE")
             )


### PR DESCRIPTION
fixes #1340