### PR TITLE
feat(t_templates): use syslog-ng default substitution instead of $(if)

### DIFF
--- a/package/etc/conf.d/conflib/_common/t_templates.conf
+++ b/package/etc/conf.d/conflib/_common/t_templates.conf
@@ -135,10 +135,10 @@ template t_splunk_hec {
     template('$(format-json
         time=$(if ("${.netsource.sc4s_use_recv_time}" eq "yes") "$R_UNIXTIME" "$S_UNIXTIME")
         host=$(lowercase ${HOST})
-        source=$(if ("${.splunk.source}" ne "") "${.splunk.source}" "SC4S")
-        sourcetype=$(if ("${.splunk.sourcetype}" ne "") "${.splunk.sourcetype}" "sc4s:fallback")
-        index=$(if ("${.splunk.index}" ne "") "${.splunk.index}" "main")
-        event="$(template ${.splunk.sc4s_template} t_hdr_msg)"
+        source=${.splunk.source:-SC4S}
+        sourcetype=${.splunk.sourcetype:-sc4s:fallback}
+        index=${.splunk.index:-main}
+        event="$(template ${.splunk.sc4s_template:-t_hdr_msg})"
         fields.*
  )');
 };


### PR DESCRIPTION
This is a tiny improvement I use mainly to see how the contribution process works and also to get to know Github actions which don't run on my fork. I don't insist on merging this, I am just trying to get more familiar with sc4s.
