### PR TITLE
feat: Support destination specific drop

### DIFF
--- a/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.jinja
+++ b/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.jinja
@@ -17,7 +17,12 @@ log{
             {{ filter }}
         };
     {%- endif %}
-    
-    destination({{ destination }});
+    if {
+        parser { 
+            app-parser(topic(sc4s-lp-dest-select-drop-{{ destination }})); 
+        };    
+    } else {
+        destination({{ destination }});
+    };   
     flags(catchall);
 };


### PR DESCRIPTION
Previously "null_queue" fitlers were applied only on the source side which is useful for dropping data with no value to any source. This PR adds support for dropping data from a specific dest in both global and select modes.