### PR TITLE
feat(f5): Support APM source type

### DIFF
--- a/docs/sources/F5/index.md
+++ b/docs/sources/F5/index.md
@@ -20,6 +20,7 @@
 | f5:bigip:gtm:dns:response:irule | None |
 | f5:bigip:ltm:failed:irule | None |
 | f5:bigip:asm:syslog | None |
+| f5:bigip:apm:syslog | None |
 | nix:syslog     | None                                                                                          |
 | f5:bigip:ltm:access_json | User defined configuration via irule producing a RFC5424 syslog event with json content within the message field `<111>1 2020-05-28T22:48:15Z foo.example.com F5 - access_json - {"event_type":"HTTP_REQUEST", "src_ip":"10.66.98.41"}` This source type requires a customer specific Splunk Add-on for utility value |
 
@@ -31,6 +32,7 @@
 | f5_bigip       | netops          | none          |
 | f5_bigip_irule | netops          | none          |
 | f5_bigip_asm   | netwaf          | none          |
+| f5_bigip_apm   | netops          | none          |
 | f5_bigip_nix   | netops          | if `f_f5_bigip` is not set the index osnix will be used          |
 | f5_bigip_access_json | netops | none |
 
@@ -53,7 +55,7 @@
 | SC4S_LISTEN_F5_BIGIP_TCP_PORT      | empty string      | Enable a TCP port for this specific vendor product using a comma-separated list of port numbers |
 | SC4S_LISTEN_F5_BIGIP_UDP_PORT      | empty string      | Enable a UDP port for this specific vendor product using a comma-separated list of port numbers |
 | SC4S_ARCHIVE_F5_BIGIP | no | Enable archive to disk for this specific source |
-| SC4S_DEST_F5_BIGIP_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
+| SC4S_DEST_F5_BIGIP_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source |
 
 ### Verification
 

--- a/package/etc/conf.d/conflib/syslog/app-syslog-f5_bigip.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-f5_bigip.conf
@@ -41,6 +41,12 @@ block parser app-syslog-f5_bigip() {
             };
             rewrite{
                 r_set_splunk_dest_update(
+                    sourcetype('f5:bigip:apm:syslog')
+                    condition(program('^tmm') and message('^(?:\d{4})[0-9A-Fa-f]{4}:\d+:\s+(?:[^:\s]{1,100}:[^:\s]{1,100}:\s*)?[0-9a-f]{8}:'))
+                );
+            };
+            rewrite{
+                r_set_splunk_dest_update(
                     sourcetype('f5:bigip:ltm:traffic')
                     condition(message('[0-9A-Fa-f]{4}\d+:\d{1,2}:\sLimiting.+from\s\d+\sto\s\d+\spackets\/sec'))
                 );


### PR DESCRIPTION
Added rewrite section to f5 to account for sourcetype `f5:bigip:apm:syslog`. 

Fixes #1423