### PR TITLE
feat: Support Beyond Trust BOMGAR

### DIFF
--- a/docs/sources/BeyondTrust/index.md
+++ b/docs/sources/BeyondTrust/index.md
@@ -1,0 +1,47 @@
+# Vendor - Beyond Trust
+
+
+## Product - Secure Remote Access (Bomgar)
+
+| Ref            | Link                                                                                                    |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| Splunk Add-on  | None                                    |
+| Product Manual | unknown   |
+
+
+### Sourcetypes
+
+| sourcetype     | notes                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------|
+| beyondtrust:sra        | None                                                                                                    |
+
+### Sourcetype and Index Configuration
+
+| key            | sourcetype     | index          | notes          |
+|----------------|----------------|----------------|----------------|
+| beyondtrust_sra     | beyondtrust:sra       | infraops          | none          |
+
+### Filter type
+
+MSG Parsing
+
+### Setup and Configuration
+
+Device setup unknown 
+
+### Options
+
+| Variable       | default        | description    |
+|----------------|----------------|----------------|
+| SC4S_ARCHIVE_BEYONDTRUST_SRA | no | Enable archive to disk for this specific source |
+| SC4S_DEST_BEYONDTRUST_SRA_HEC | no | When Splunk HEC is disabled globally set to yes to enable this specific source | 
+| SC4S_DEST_BEYONDTRUST_SRA_SPLUNK_HEC_FMT | json | Restructure data from vendor format to json for splunk destinations |
+| SC4S_DEST_BEYONDTRUST_SRA_SYSLOG_FMT | json | Restructure data from vendor format to SDATA for SYSLOG destinations |
+
+### Verification
+
+An active device will generate frequent events. Use the following search to validate events are present per source device
+
+```
+index=<asconfigured> sourcetype=beyondtrust:sra | stats count by host
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Arista: sources/Arista/index.md
       - Avaya: sources/Avaya/index.md
       - "Avi Networks": sources/Avi_Networks/index.md
+      - BeyondTrust: sources/BeyondTrust/index.md
       - Brocade: sources/Brocade/index.md
       - Buffalo: sources/Buffalo/index.md
       - Checkpoint: sources/Checkpoint/index.md

--- a/package/etc/conf.d/conflib/_common/t_templates.conf
+++ b/package/etc/conf.d/conflib/_common/t_templates.conf
@@ -151,3 +151,8 @@ template t_fallback_kv {
 
 
 template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
+
+
+template t_json_values {
+    template('$(format-json --key .values.* --shift-levels 2)');
+    };

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-beyondtrust_sra.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-beyondtrust_sra.conf
@@ -1,0 +1,48 @@
+template t_beyondtrust_sra {
+        template("${.values.siteid}:${.values.seq}:${values.num}:${.gb.message}");
+};
+
+block parser app-postfilter-beyondtrust_sra() {    
+    channel {
+            
+        parser{
+            grouping-by(
+                scope(program)
+                key("${.values.siteid}")
+                trigger("$(context-length)" >= "${.values.num}")
+                sort-key("${.values.seq}")
+                aggregate(
+                    value(".gb.complete" "1")
+                    value(".gb.message" "$(implode ';' $(list-slice 0:-1 $(context-values ${.message})))")
+                    value(".values.siteid", "00")
+                    value(".values.num", "${.values.siteid}@1")
+                    value("PROGRAM" "${PROGRAM}@1")
+                    value(".splunk.sc4s_template", "t_beyondtrust_sra")
+                    value("fields.sc4s_merge_count", "$(context-length)")
+                    value(".structured.level", "full")
+                    value(".structured.splunk_hec", "json")
+                    value(".structured.syslog", "sdata")
+                    inherit-mode(context)
+                )
+                timeout(10)
+            );
+        };
+        
+        rewrite { 
+            r_set_splunk_dest_update(
+                vendor('null') product('queue')
+                condition("${.gb.complete}" ne "1")
+            );
+        };
+
+
+   };
+};
+application app-postfilter-beyondtrust_sra[sc4s-postfilter] {
+	filter { 
+        "${PROGRAM}" eq "BG"
+        and "${.values.num}" > "1";
+    };	
+    parser { app-postfilter-beyondtrust_sra(); };   
+};
+

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
@@ -59,7 +59,7 @@ block parser app-postfilter-cisco_acs() {
 application app-postfilter-cisco_acs[sc4s-postfilter] {
 	filter { 
         program('CSCOacs' type(string) flags(prefix))
-        and "${.values.num}" ne "1";
+        and "${.values.num}" > "1";
     };	
     parser { app-postfilter-cisco_acs(); };   
 };

--- a/package/etc/conf.d/conflib/syslog/app-syslog-beyondtrust_sra.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-beyondtrust_sra.conf
@@ -1,0 +1,100 @@
+block parser app-syslog-beyondtrust_sra() {    
+ channel {
+        rewrite {
+            r_set_splunk_dest_default(
+                index('infraops')
+                sourcetype('beyondtrust:sra')
+                vendor("beyondtrust")
+                product("sra")
+                template('t_msg_only')
+            );              
+            set("full" value(".structured.level"));
+            set("json" value(".structured.splunk_hec"));
+            set("sdata" value(".structured.syslog"));
+        };
+        parser {
+            regexp-parser(
+                prefix(".tmp.")
+                patterns('^(?<siteid>\d+):(?<seq>\d+):(?<num>\d+):(?<message>.*)')
+            );            
+            kv-parser(
+                prefix(".values.") 
+                pair-separator(";")
+                template('${.tmp.message}')
+            );            
+        };        
+        rewrite {
+            set('${.tmp.siteid}' value('.values.siteid'));
+            set('${.tmp.seq}' value('.values.seq'));
+            set('${.tmp.num}' value('.values.num'));
+            set('${.tmp.message}' value('.message'));
+            groupunset(values(".tmp.*"));
+        };
+   };
+};
+application app-syslog-beyondtrust_sra[sc4s-syslog] {
+	filter { 
+        "${PROGRAM}" eq "BG"
+    };	
+    parser { app-syslog-beyondtrust_sra(); };   
+};
+
+
+
+#Destination type formatters
+block parser app-syslog-beyondtrust_sra-splunk_hec() {
+    channel {
+        rewrite{
+            set("t_json_values", value(".splunk.sc4s_template"));      
+        };
+    };
+};
+application app-syslog-beyondtrust_sra-splunk_hec[sc4s-lp-dest-format-hec_fmt] {
+    filter {
+        "${${fields.sc4s_vendor}}" eq "beyondtrust"
+        and "${fields.sc4s_product}" eq "sra"
+        and (
+            "`SC4S_DEST_BEYONDTRUST_SRA_SPLUNK_HEC_FMT`" eq ""
+            or "`SC4S_DEST_BEYONDTRUST_SRA_SPLUNK_HEC_FMT`" eq "JSON"
+        )
+    };
+    parser { app-syslog-beyondtrust_sra-splunk_hec(); };   
+};
+
+block parser app-syslog-beyondtrust_sra-syslog() {
+    channel {
+        parser {
+            map-value-pairs(
+                key('.values.*' rekey(shift-levels(2) add-prefix(".SDATA.sc4sfields@27389.")))
+            );
+            map-value-pairs(
+                key('fields.*' rekey(shift-levels(2) add-prefix(".SDATA.sc4smeta@27389.")))
+            );
+        };        
+        rewrite{
+            unset(value('MESSAGE'));
+        };
+    };
+};
+application app-syslog-beyondtrust_sra-syslog[sc4s-lp-dest-format-syslog] {
+    filter {
+        "${${fields.sc4s_vendor}}" eq "beyondtrust"
+        and "${fields.sc4s_product}" eq "sra"
+        and (
+            "`SC4S_DEST_BEYONDTRUST_SRA_SYSLOG_FMT`" eq ""
+            or "`SC4S_DEST_BEYONDTRUST_SRA_SYSLOG_FMT`" eq "SDATA"
+        )
+    };
+    parser { app-syslog-beyondtrust_sra-syslog(); };   
+};
+
+block parser app-syslog-beyondtrust_sra-bsd() {
+    channel {
+        rewrite{
+            set('$(template ${.splunk.sc4s_template:-t_hdr_msg})' value('MESSAGE'));
+        };
+    };
+};
+application app-syslog-beyondtrust_sra-bsd[sc4s-lp-dest-format-bsd] {
+    parser { app-syslog-beyondtrust_sra-bsd(); };   
+};

--- a/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.jinja
+++ b/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.jinja
@@ -17,11 +17,24 @@ log{
             {{ filter }}
         };
     {%- endif %}
+    #These parsers can be used to make destination type or destination specific
+    #changes to the format of the event for example moving the kv pairs from a parsed
+    #MESSAGE to the sdata fields
     if {
         parser { 
             app-parser(topic(sc4s-lp-dest-select-drop-{{ destination }})); 
         };    
     } else {
+        if {
+            parser { 
+                app-parser(topic(sc4s-lp-dest-format-{{ destination }})); 
+            };    
+        } elif {
+            parser { 
+                app-parser(topic(sc4s-lp-dest-format-{{ dtype }})); 
+            };    
+        } else {};
+
         destination({{ destination }});
     };   
     flags(catchall);

--- a/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.py
+++ b/package/etc/conf.d/log_paths/2/lp_dest_alts_global/plugin.py
@@ -39,6 +39,7 @@ for vn, vv in os.environ.items():
 
         global_dests[r] = {
             "destination": f"d_hec_fmt{suffix}",
+            "dtype": "hec_fmt",
             "mode": modev,
             "filter": "",
         }
@@ -57,6 +58,7 @@ for vn, vv in os.environ.items():
         if modev.upper() in ("GLOBAL", "SELECT"):
             global_dests[r] = {
                 "destination": f"d_{t.lower()}_{r.lower()}",
+                "dtype": t.lower(),
                 "mode": modev,
                 "filter": filter,
             }
@@ -64,6 +66,10 @@ for vn, vv in os.environ.items():
 
 for d, m in global_dests.items():
     msg = tm.render(
-        id=d, destination=m["destination"], mode=m["mode"], filter=m["filter"]
+        id=d,
+        destination=m["destination"],
+        mode=m["mode"],
+        filter=m["filter"],
+        dtype=m["dtype"],
     )
     print(msg)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -31,15 +31,19 @@ services:
     tty: true
     links:
       - splunk
-      - nc
+      - ncsyslog
+      - ncbsd
     environment:
       - SC4S_DEST_SPLUNK_HEC_DEFAULT_URL=https://splunk:8088
       - SC4S_DEST_SPLUNK_HEC_DEFAULT_TOKEN=${SPLUNK_HEC_TOKEN}
       - SC4S_DEST_SPLUNK_HEC_DEFAULT_TLS_VERIFY=no
-      - SC4S_DEST_SYSLOG_NC_HOST=nc
-      - SC4S_DEST_SYSLOG_NC_PORT=2514
-      - SC4S_DEST_SYSLOG_NC_MODE=GLOBAL
-      - SC4S_DEST_SYSLOG_NC_IETF=no
+      - SC4S_DEST_SYSLOG_NCSYSLOG_HOST=ncsyslog
+      - SC4S_DEST_SYSLOG_NCSYSLOG_PORT=2514
+      - SC4S_DEST_SYSLOG_NCSYSLOG_MODE=GLOBAL
+      - SC4S_DEST_SYSLOG_NCSYSLOG_IETF=no
+      - SC4S_DEST_BSD_NCBSD_HOST=ncbsd
+      - SC4S_DEST_BSD_NCBSD_PORT=2514
+      - SC4S_DEST_BSD_NCBSD_MODE=GLOBAL
       # - SC4S_DEST_SPLUNK_HEC_SECOND_URL=https://splunk:8088
       # - SC4S_DEST_SPLUNK_HEC_SECOND_TOKEN=${SPLUNK_HEC_TOKEN}
       # - SC4S_DEST_SPLUNK_HEC_SECOND_TLS_VERIFY=no
@@ -83,13 +87,18 @@ services:
       - SPLUNK_APPS_URL=https://github.com/splunk/splunk-configurations-base-indexes/releases/download/v1.0.0/splunk_configurations_base_indexes-1.0.0.tar.gz
     volumes:
       - splunk-var:/opt/splunk/var
-  nc:
+  ncsyslog:
     build:
       context: ..
       dockerfile: tests/Dockerfile.nc
-    hostname: nc
+    hostname: ncsyslog
     command: nc -lkv 2514
-
+  ncbsd:
+    build:
+      context: ..
+      dockerfile: tests/Dockerfile.nc
+    hostname: ncbsd
+    command: nc -lkv 2514
 volumes:
   splunk-var:
     external: false

--- a/tests/test_beyondtrust.py
+++ b/tests/test_beyondtrust.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Splunk, Inc.
+#
+# Use of this source code is governed by a BSD-2-clause-style
+# license that can be found in the LICENSE-BSD2 file or at
+# https://opensource.org/licenses/BSD-2-Clause
+
+from jinja2 import Environment
+
+from .sendmessage import *
+from .splunkutils import *
+from .timeutils import *
+
+import pytest
+
+env = Environment()
+
+
+# <134>Feb 18 09:37:41 xxxxxx swlogd: bcmd esm info(5) phy_nlp_enable_set: u=0 p=1 enable:1 phyPresent:YES
+testdata = [
+    "{{ mark }}{{ bsd }} {{ host }} BG[123]: 1427:01:01:event=logout;site=support.xxx.xxx.gov;target=rep_client;when=1643824736;who=unknown (asdf) using password;who_ip=10.0.85.35",
+]
+
+
+@pytest.mark.parametrize("event", testdata)
+def test_beyondtrust_sra(
+    record_property, setup_wordlist, get_host_key, setup_splunk, setup_sc4s, event
+):
+    host = get_host_key
+
+    dt = datetime.datetime.now()
+    iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<166>", bsd=bsd, host=host)
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search index=infraops _time={{ epoch }} sourcetype="beyondtrust:sra" (host="{{ host }}" OR "{{ host }}")'
+    )
+    search = st.render(epoch=epoch, host=host)
+
+    resultCount, eventCount = splunk_single(setup_splunk, search)
+
+    record_property("host", host)
+    record_property("resultCount", resultCount)
+    record_property("message", message)
+
+    assert resultCount == 1
+
+
+def test_beyondtrust_parts(
+    record_property, setup_wordlist, get_host_key, setup_splunk, setup_sc4s
+):
+    host = get_host_key
+
+    dt = datetime.datetime.now()
+    iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    event = "{{ mark }}{{ bsd }} {{ host }} BG[123]: 1427:01:02:event=logout;site=support.xxx.xxx.gov;target=rep_client;when=1643824736;who=unknown (asdf) using password;who_ip=10.0.85.35"
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<166>", bsd=bsd, host=host)
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    event = "{{ mark }}{{ bsd }} {{ host }} BG[123]: 1427:02:02:foo=bar;this=that"
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<166>", bsd=bsd, host=host)
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search index=infraops _time={{ epoch }} sourcetype="beyondtrust:sra" (host="{{ host }}" OR "{{ host }}")'
+    )
+    search = st.render(epoch=epoch, host=host)
+
+    resultCount, eventCount = splunk_single(setup_splunk, search)
+
+    record_property("host", host)
+    record_property("resultCount", resultCount)
+    record_property("message", message)
+
+    assert resultCount == 1


### PR DESCRIPTION
fixes #1422

This PR adds bomgar now known as BeyondTrust Secure Remote access. For the first time format translation is supported in sc4s. Format translation is on by default and will transform the header + kv pair format into json when forwarded to Splunk and into SDATA pairs when forwarded by IETF syslog. BSD syslog will retain the original format.