### PR TITLE
feat: Support invalid FTD events

### DIFF
--- a/package/etc/conf.d/conflib/raw/app-raw-cisco_ftd_nopri-bsd.conf
+++ b/package/etc/conf.d/conflib/raw/app-raw-cisco_ftd_nopri-bsd.conf
@@ -1,0 +1,36 @@
+block parser app-raw-cisco_ftd_nopri-bsd() {    
+    channel {
+        parser { 
+            regexp-parser(
+                prefix(".tmp.")
+                patterns('(?<timestamp>[A-Z][a-z]{2} *\d{1,2} \d{4} \d\d:\d\d:\d\d) (?<host>[^ ]+)(?: : | *)(?<message>%FTD-\d-\d+:.*)')
+            );
+        };
+        rewrite {
+            set("${.tmp.message}", value("MESSAGE"));
+            set("${.tmp.host}", value("HOST"));
+        };
+        parser {
+            date-parser-nofilter(format(
+                    '%b %d %H:%M:%S.%f',
+                    '%b %d %H:%M:%S',
+                    '%b %d %I:%M:%S %p.%f',
+                    '%b %d %I:%M:%S %p',
+                    '%b %d %Y %I:%M:%S %p.%f'
+                    '%b %d %Y %H:%M:%S.%f',
+                    '%b %d %Y %H:%M:%S',
+                )
+                template("${.tmp.timeStamp}")
+            );
+        };            
+        
+        rewrite {
+            set("cisco_ftd_nopri", value("fields.sc4s_syslog_format"));
+            groupunset(values('.tmp.*'));
+        };                       
+        
+   };
+};
+application app-raw-cisco_ftd_nopri-bsd[sc4s-raw-syslog] {
+    parser { app-raw-cisco_ftd_nopri-bsd(); };   
+};

--- a/package/etc/conf.d/conflib/raw/app-raw-cisco_ftd_nopri-iso.conf
+++ b/package/etc/conf.d/conflib/raw/app-raw-cisco_ftd_nopri-iso.conf
@@ -1,0 +1,36 @@
+block parser app-raw-cisco_ftd_nopri-iso() {    
+    channel {
+        parser { 
+            regexp-parser(
+                prefix(".tmp.")
+                patterns('(?<timestamp>\d{4}-\d\d-\d\d.\d\d:\d\d:\d\d[^ ]*) (?<host>[^ ]+)(?: : | *)(?<message>%FTD-\d-\d+:.*)')
+            );
+        };
+        rewrite {
+            set("${.tmp.message}", value("MESSAGE"));
+            set("${.tmp.host}", value("HOST"));
+        };
+        parser { 
+            date-parser(
+                format(
+                    '%Y-%m-%dT%T.%f%z',
+                    '%Y-%m-%dT%T%z',                    
+                    '%Y-%m-%d %T.%f%z',
+                    '%Y-%m-%d %T%z',                    
+                    '%Y-%m-%d%T.%f%z',
+                    '%Y-%m-%d%T%z',                     
+                ) 
+                template("${.tmp.timestamp}")
+            );
+        };             
+        
+        rewrite {
+            set("cisco_ftd_nopri", value("fields.sc4s_syslog_format"));
+            groupunset(values('.tmp.*'));
+        };                       
+        
+   };
+};
+application app-raw-cisco_ftd_nopri-iso[sc4s-raw-syslog] {
+    parser { app-raw-cisco_ftd_nopri-iso(); };   
+};


### PR DESCRIPTION
Certain cisco devices send a "cisco like" but not correct cisco header and are missing the PRI and header separator. This seems to impact threat defense events only.