### PR TITLE
fix: support bsd date

### DIFF
--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-arista_eos.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-arista_eos.conf
@@ -8,7 +8,7 @@ block parser app-almost-syslog-arista_eos() {
                 flags(ignore-case)
             );
             syslog-parser(
-                flags(assume-utf8)
+                flags(assume-utf8, guess-timezone)
                 template("${.tmp.pri} ${.tmp.timestamp} ${.tmp.host} ${.tmp.program}: ${.tmp.message}")
             );
         };    

--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslogz-bsd-onedigitday.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslogz-bsd-onedigitday.conf
@@ -1,0 +1,22 @@
+block parser app-almost-syslogz-bsd-onedigitday() {    
+    channel {
+        parser {
+            regexp-parser(
+                prefix(".tmp.")
+                patterns('^(?<pri>\<\d+\>) ?(?<tsp1>[A-Z][a-z]{2})  ?(?<tsp2>\d \d\d:\d\d:\d\d) (?<message>.*)')
+            );   
+            syslog-parser(
+                flags(assume-utf8, guess-timezone)
+                template("${.tmp.pri} ${.tmp.tsp1} 0${.tmp.tsp2} ${.tmp.message}")
+            );
+        };        
+        rewrite {
+            groupunset(values(".tmp.*"));
+            set("rfc3164_bsdonedigitday", value("fields.sc4s_syslog_format"));
+        };                       
+        
+    };
+};
+application app-almost-syslogz-bsd-onedigitday[sc4s-almost-syslog] {
+    parser { app-almost-syslogz-bsd-onedigitday(); };   
+};


### PR DESCRIPTION
When the leading zero/space is missing for BSD.
fixes #1438 