### PR TITLE
feat: support custom status port

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -390,3 +390,8 @@ It is best to design your deployment so that the disk buffer will drain after co
 (while incoming data continues at the same general rate).  Since "your mileage may vary" with different combinations of
 data load, instance type, and disk subsystem performance, it is good practice to provision a box that performs twice as
 well as is required for your max EPS. This headroom will allow for rapid recovery after a connectivity outage.
+
+
+# Misc options
+
+* `SC4S_LISTEN_STATUS_PORT` Change the "status" port used by the internal health check process default value is `8080`

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 function join_by { local d=$1; shift; local f=$1; shift; printf %s "$f" "${@/#/$d}"; }
 
+export SC4S_LISTEN_STATUS_PORT=${SC4S_LISTEN_STATUS_PORT:=8080}
+
 # These path variables allow for a single entrypoint script to be utilized for both Container and BYOE runtimes
 export SC4S_LISTEN_DEFAULT_TCP_PORT=${SC4S_LISTEN_DEFAULT_TCP_PORT:=514}
 export SC4S_LISTEN_DEFAULT_UDP_PORT=${SC4S_LISTEN_DEFAULT_UDP_PORT:=514}
@@ -154,7 +156,7 @@ $SC4S_SBIN/syslog-ng --no-caps $SC4S_CONTAINER_OPTS -s >>$SC4S_VAR/log/syslog-ng
 if command -v goss &> /dev/null
 then
   echo starting goss
-  goss -g $SC4S_ETC/goss.yaml serve -l 0.0.0.0:8080 --format json >/dev/null 2>/dev/null &
+  goss -g $SC4S_ETC/goss.yaml serve -l 0.0.0.0:$SC4S_LISTEN_STATUS_PORT --format json >/dev/null 2>/dev/null &
 fi
 
 # OPTIONAL for BYOE:  Comment out/remove all remaining lines and launch syslog-ng directly from systemd

--- a/package/sbin/healthcheck.sh
+++ b/package/sbin/healthcheck.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -e
-curl -s --fail http://localhost:8080/healthz
+export SC4S_LISTEN_STATUS_PORT=${SC4S_LISTEN_STATUS_PORT:=8080}
+curl -s --fail http://localhost:${SC4S_LISTEN_STATUS_PORT}/healthz


### PR DESCRIPTION
new option var `SC4S_LISTEN_STATUS_PORT` allows for the status port to be changed when a conflict with another product on the same host is encountered not used in k8s deployments