### PR TITLE
fix: powerswitch-n greedy filter

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-dell_switch_n.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-dell_switch_n.conf
@@ -3,7 +3,7 @@ block parser app-syslog-dell_switch_n() {
         
         filter { 
             program('[A-Z]+')
-            and match('\w+' value('PID'));
+            and not match('^\d+$' value('PID'));
         };   
         parser { 
             regexp-parser(


### PR DESCRIPTION
Certain unexpected matches causing incorrect sourcetype