### PR TITLE
feat: Use compact 5424 template by default

### DIFF
--- a/package/etc/conf.d/conflib/_common/t_templates.conf
+++ b/package/etc/conf.d/conflib/_common/t_templates.conf
@@ -76,7 +76,7 @@ template t_5424_hdr_sdata {
 
 #Send - for host and date to conserve bytes useful for destinations such as splunk where the fields are repetitive
 template t_5424_hdr_sdata_compact {
-        template('- - $(if ("${PROGRAM}" ne "") "${PROGRAM}" "-") $(if ("${PID}" ne "") "${PID}" "-") $(if ("${MSGID}" ne "") "${MSGID}" "-") $(if ("${SDATA}" ne "") "${SDATA}" "-") ${MESSAGE}');
+        template('- - $(if ("${PROGRAM}" ne "") "${PROGRAM}" "-") $(if ("${PID}" ne "") "${PID}" "-") $(if ("${MSGID}" ne "") "${MSGID}" "-") $(if ("${SDATA}" ne "") "${SDATA}" "-")$(if ("${MESSAGE}" ne "") " ${MESSAGE}" "")');
         };        
 
 # ===============================================================================================

--- a/package/etc/conf.d/conflib/_splunk/splunkfields.conf
+++ b/package/etc/conf.d/conflib/_splunk/splunkfields.conf
@@ -32,7 +32,7 @@ block rewrite r_set_splunk_dest_default(
                               index("main")
                               source("${.splunk.source}")                              
                               sourcetype("${.splunk.sourcetype}")
-                              template('$(if (match("rfc5424_strict" value("fields.sc4s_syslog_format"))) "t_5424_hdr_sdata_msg" "t_hdr_msg")')
+                              template('$(if (match("^rfc5424" value("fields.sc4s_syslog_format"))) "t_5424_hdr_sdata_compact" "t_hdr_msg")')
                               tag("default")
                               vendor("${fields.sc4s_vendor}")
                               product("${fields.sc4s_product}")

--- a/package/etc/conf.d/conflib/syslog/app-syslog-checkpoint_syslog.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-checkpoint_syslog.conf
@@ -14,7 +14,7 @@ block parser app-syslog-checkpoint_syslog() {
                 sourcetype('cp_log:syslog')
                 vendor("checkpoint")
                 product("syslog")
-                template('t_5424_hdr_sdata_msg')
+                template('t_5424_hdr_sdata_compact')
             );                                
         };                       
             

--- a/package/etc/conf.d/conflib/syslog/app-syslog-hpe_ilo.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-hpe_ilo.conf
@@ -7,7 +7,7 @@ block parser app-syslog-hpe_ilo() {
                 sourcetype('hpe:ilo')
                 vendor("hpe")
                 product("ilo")
-                template('t_5424_hdr_sdata_msg')
+                template('t_5424_hdr_sdata_compact')
             );
         };
 

--- a/package/etc/conf.d/conflib/syslog/app-syslog-juniper_junos_structured.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-juniper_junos_structured.conf
@@ -6,7 +6,7 @@ block parser app-syslog-juniper_junos_structured() {
                 sourcetype('juniper:unknown')
                 vendor("juniper")
                 product("junos_structured")
-                template("t_5424_hdr_sdata_msg")
+                template("t_5424_hdr_sdata_compact")
             ); 
         };       
         filter(f_is_rfc5424_strict);

--- a/package/etc/conf.d/conflib/syslog/app-syslog-polycom_rprm.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-polycom_rprm.conf
@@ -6,7 +6,7 @@ block parser app-syslog-polycom_rprm() {
                 sourcetype('polycom:rprm:syslog')
                 vendor("polycom")
                 product("rprm")
-                template('t_5424_hdr_sdata_msg')
+                template('t_5424_hdr_sdata_compact')
             );              
         };       
        

--- a/package/etc/conf.d/conflib/syslog/app-syslog-tanium.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-tanium.conf
@@ -11,6 +11,7 @@ block parser app-syslog-tanium() {
                 sourcetype('tanium')
                 vendor("tanium")
                 product("syslog")
+                template('t_5424_hdr_sdata_compact')
             );            
             set("${.SDATA.tanium_droid@017472.Question}", value(".tmp.question"));
             subst(" ", '', value(".tanium.question"));
@@ -42,7 +43,6 @@ block parser app-syslog-tanium() {
             set("tanium:detect:openioc", value(".splunk.sourcetype") condition( match('\"Intel Type\"\:\"openioc\"' value('SDATA'))));
             set("tanium:detect:yara", value(".splunk.sourcetype") condition( match('\"Intel Type\"\:\"yara\"' value('SDATA'))));
             
-            set("t_5424_hdr_sdata_msg", value(".splunk.sc4s_template"));
             #set-tag("log_path_known");
             #set-tag("tanium");      
                   

--- a/package/etc/conf.d/sources/internal.conf
+++ b/package/etc/conf.d/sources/internal.conf
@@ -18,7 +18,7 @@ source s_internal {
                 vendor('splunk')
                 product('sc4s')
                 class("events")
-                template('t_5424_hdr_sdata_msg')
+                template('t_5424_hdr_sdata_compact')
             ) 
         };
         rewrite {

--- a/package/etc/local_config/app_parsers/syslog/app-nix_example.conf
+++ b/package/etc/local_config/app_parsers/syslog/app-nix_example.conf
@@ -11,7 +11,7 @@ block parser nix_example-parser() {
                 #this value is used to lookup runtime settings such as index from splunk_metadata.csv
                 vendor("nix")
                 product("example")                                                    
-                #Common values are t_hdr_msg (BSD Style syslog without timestamp and host) and t_5424_hdr_sdata_msg RFC5424 with optional sdata and msg
+                #Common values are t_hdr_msg (BSD Style syslog without timestamp and host) and t_5424_hdr_sdata_compact RFC5424 with optional sdata and msg
                 #These values will be automatically selected based on the format of the source the specific value is only needed in special cases
                 #template("t_hdr_msg") 
             );                         


### PR DESCRIPTION
Use the compact 5424 template with "-" place holders for host and timestamp to conserve bytes by default