### PR TITLE
fix: limit one day parser

### DIFF
--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslogz-bsd-onedigitday.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslogz-bsd-onedigitday.conf
@@ -3,11 +3,11 @@ block parser app-almost-syslogz-bsd-onedigitday() {
         parser {
             regexp-parser(
                 prefix(".tmp.")
-                patterns('^(?<pri>\<\d+\>) ?(?<tsp1>[A-Z][a-z]{2})  ?(?<tsp2>\d \d\d:\d\d:\d\d) (?<message>.*)')
+                patterns('^(?<pri>\<\d+\>) ?(?<tsp1>[A-Z][a-z]{2}) (?<tsp2>\d \d\d:\d\d:\d\d) (?<message>.*)')
             );   
             syslog-parser(
                 flags(assume-utf8, guess-timezone)
-                template("${.tmp.pri} ${.tmp.tsp1} 0${.tmp.tsp2} ${.tmp.message}")
+                template("${.tmp.pri} ${.tmp.tsp1}  ${.tmp.tsp2} ${.tmp.message}")
             );
         };        
         rewrite {


### PR DESCRIPTION
This parser should only be required for invalid headers with no space or zero padding in day number