### PR TITLE
fix: fortinet events with "ms" in time field but no epoch

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-fortigate_fortiweb.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-fortigate_fortiweb.conf
@@ -61,10 +61,12 @@ block parser app-syslog-fortigate_fortiweb() {
             parser {
                 date-parser-nofilter(
                     format(
-                        '%Y-%m-%d:%H:%M:%S%z',
-                        '%Y-%m-%d:%H:%M:%S'
+                        '%Y-%m-%dT%H:%M:%S%z',
+                        '%Y-%m-%dT%H:%M:%S.%f%z',
+                        '%Y-%m-%dT%H:%M:%S',
+                        '%Y-%m-%dT%H:%M:%S.%f'
                         )
-                    template("${.values.date}:${.values.time}${.values.tz}")
+                    template("${.values.date}T${.values.time}${.values.tz}")
                 );
             };
         };


### PR DESCRIPTION
fixes #1582