### PR TITLE
fix: incorrect vendor for bluecoat

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-symantec_proxysg.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-symantec_proxysg.conf
@@ -5,7 +5,7 @@ block parser app-syslog-symantec_proxysg() {
             r_set_splunk_dest_default(
                 index("netops")
                 sourcetype('bluecoat:proxysg:syslog')
-                vendor('symantec')
+                vendor('bluecoat')
                 product('proxy')
                 class('syslog')
             );
@@ -23,7 +23,7 @@ block parser app-syslog-symantec_proxysg() {
                 r_set_splunk_dest_default(
                     index("netproxy")
                     sourcetype('bluecoat:proxysg:access:kv')
-                    vendor('symantec')
+                    vendor('bluecoat')
                     product('proxy')
                     class('splunkkv')
                     template('t_msg_only')


### PR DESCRIPTION
Revert change to symantec from bluecoat to prevent breaking customer deployments