### PR TITLE
[FIX] copy all context files from configmap mountpoint

### DIFF
--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -80,7 +80,7 @@ if [ "$SC4S_RUNTIME_ENV" == "k8s" ]
 then
   mkdir -p $SC4S_ETC/conf.d/configmap/context/
   mkdir -p $SC4S_ETC/conf.d/configmap/config/
-  cp -f $SC4S_ETC/conf.d/configmap/context/splunk_metadata.csv $SC4S_ETC/conf.d/local/context/splunk_metadata.csv
+  cp -f $SC4S_ETC/conf.d/configmap/context/* $SC4S_ETC/conf.d/local/context/
 
 else
   cp -R -f $SC4S_ETC/local_config/* $SC4S_ETC/conf.d/local/config/


### PR DESCRIPTION
This is for issues:
#1639 
#1576

fixes:
- not all context files copied from configmap mountpoint