### PR TITLE
Update switch.md

### DIFF
--- a/docs/sources/vendor/Brocade/switch.md
+++ b/docs/sources/vendor/Brocade/switch.md
@@ -27,7 +27,7 @@
 ## Parser Configuration
 
 ```c
-#/opt/sc4s/local/config/app-parsers/app-vps-brocade_syslog.conf
+#/opt/sc4s/local/config/app_parsers/app-vps-brocade_syslog.conf
 #File name provided is a suggestion it must be globally unique
 
 application app-vps-test-brocade_syslog[sc4s-vps] {


### PR DESCRIPTION
The file path for app parsers uses an underscore and not a dash in the current version.

`[root@nyc128-sc4s-01 app_parsers]# pwd
/opt/sc4s/local/config/app_parsers`