### PR TITLE
feat(citrix_netscaler): ADDON-54411 added filter for Citrix APPFW CEF…

### DIFF
--- a/docs/sources/vendor/Citrix/netscaler.md
+++ b/docs/sources/vendor/Citrix/netscaler.md
@@ -17,12 +17,16 @@
 | sourcetype     | notes                                                                                                   |
 |----------------|---------------------------------------------------------------------------------------------------------|
 | citrix:netscaler:syslog         | None                                                                                                    |
+| citrix:netscaler:appfw         | None                                                                                                    |
+| citrix:netscaler:appfw:cef     | None                                                                                                    |
 
 ## Sourcetype and Index Configuration
 
 | key            | sourcetype     | index          | notes          |
 |----------------|----------------|----------------|----------------|
 | citrix_netscaler         | citrix:netscaler:syslog         | netfw          | none           |
+| citrix_netscaler         | citrix:netscaler:appfw         | netfw          | none           |
+| citrix_netscaler         | citrix:netscaler:appfw:cef         | netfw          | none           |
 
 ## Source Setup and Configuration
 

--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-citrix_netscaler.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-citrix_netscaler.conf
@@ -47,7 +47,7 @@ block parser app-almost-syslog-citrix_netscaler() {
         };
         rewrite {
             r_set_splunk_dest_update_v2(
-                 sourcetype('citrix:netscaler:appfw') condition(message('[^|]APPFW[^|]'))
+                 sourcetype('citrix:netscaler:appfw') condition(message(':(\s+\S+)?\s+APPFW(\s+\S+){3}\s+:'))
             );
         };
         rewrite {

--- a/package/etc/conf.d/conflib/cef/app-cef-citrix_netscaler.conf
+++ b/package/etc/conf.d/conflib/cef/app-cef-citrix_netscaler.conf
@@ -1,0 +1,17 @@
+block parser app-cef-citrix_netscaler() {
+    channel {
+        rewrite {
+            r_set_splunk_dest_update_v2(
+                index("netfw")
+                sourcetype('citrix:netscaler:appfw:cef')                
+            );
+        };
+    };
+};
+application app-cef-citrix_netscaler[cef] {
+	filter{
+        match("Citrix" value(".metadata.cef.device_vendor"))
+        and match('APPFW' value(".metadata.cef.device_event_class"));
+    };
+    parser { app-cef-citrix_netscaler(); };
+};


### PR DESCRIPTION
* Added the filter for Citrix APPFW (firewall) CEF events.
* Updated the filter criteria for `citrix:netscaler:appfw` sourcetype to correctly map the events to the respective sourcetype as below.

The below event should get assigned to `citrix:netscaler:syslog` sourcetype.

<pre>11/10/2022:05:07:01 GMT test-ctitrixns-geneva-vital 0-PPE-0 : default GUI CMD_EXECUTED 327515 0 :  User nsroot - Remote_ip 10.2.7.117 - Command "show system entitydata appfwprofile APPFW_BLOCK "appfirewallviolwellformednessviolationsperprofile,appfirewallviolxdosviolationsperprofile,appfirewallviolmsgvalviolationsperprofile,appfirewallviolwsiviolationsperprofile,appfirewallviolxmlsqlviolationsperprofile,appfirewallviolxmlxssviolationsperprofile,appfirewallviolxmlattachmentviolationsperprofile,appfirewallviolxmlsoapfaultviolationsperprofile" -last 1 DAYS -dataSource default -partitionid 0" - Status "Success"</pre>

The below event should get assigned to `citrix:netscaler:appfw` sourcetype.

<pre>11/10/2022:05:19:37 GMT test-ctitrixns-sultan-lithium 0-PPE-0 : default APPFW APPFW_STARTURL 5687021 0 :  10.160.44.137 392811-PPE0 - test_profile Disallow Illegal URL: http://10.160.0.10/0bef</pre> <not blocked></pre>
