### PR TITLE
fix(citrix_netscaler): updated the filter for syslog events

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-citrix_netscaler_svm.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-citrix_netscaler_svm.conf
@@ -5,7 +5,7 @@ block parser app-syslog-citrix_netscaler_svm() {
             regexp-parser(
                 template("${MESSAGE}")
                 prefix(".tmp.")
-                patterns('(?<host>[^ ]*) (?<timestamp>(?<tspart1>\d\d)[^ ]*(?: [^ ]+)?) +:')
+                patterns('(?<host>[^\s]*)\s+(?<timestamp>(?<tspart1>\d\d)[^\s]*(?:\s[^\s]+)?)(?:\s+\S+){2}\s+:')
             );
         };
         if {
@@ -36,7 +36,7 @@ block parser app-syslog-citrix_netscaler_svm() {
                 template("t_hdr_msg")
             );
             r_set_splunk_dest_update_v2(
-                 sourcetype('citrix:netscaler:appfw') condition(message('[^|]APPFW[^|]'))
+                 sourcetype('citrix:netscaler:appfw') condition(message(':(\s+\S+)?\s+APPFW(\s+\S+){3}\s+:'))
             );
         };
     };

--- a/tests/test_citrix_netscaler.py
+++ b/tests/test_citrix_netscaler.py
@@ -53,7 +53,7 @@ def test_citrix_netscaler(record_property, setup_wordlist, setup_splunk, setup_s
     assert resultCount == 1
 
 
-# <134>Jun 18 18:18:42 svm_service: 1.1.1.1 18/06/2020:16:18:42 GMT : GUI CMD_EXECUTED : User nsroot - Remote_ip 10.55.1.100 - Command "login login tenant_name=Owner,password=***********,challenge_response=***********,token=1c81504d124245d,client_port=-1,cert_verified=false,sessionid=***********,session_timeout=900,permission=superuser" - Status "Done"
+# <134>Jun 18 18:18:42 svm_service: 1.1.1.1  18/06/2020:16:18:42 GMT mynetscaler2 0-PPE-0 : GUI CMD_EXECUTED : User nsroot - Remote_ip 10.55.1.100 - Command "login login tenant_name=Owner,password=***********,challenge_response=***********,token=1c81504d124245d,client_port=-1,cert_verified=false,sessionid=***********,session_timeout=900,permission=superuser" - Status "Done"
 def test_citrix_netscaler_sdx(
     record_property, setup_wordlist, setup_splunk, setup_sc4s
 ):
@@ -70,7 +70,7 @@ def test_citrix_netscaler_sdx(
     epoch = epoch[:-7]
 
     mt = env.from_string(
-        '{{ mark }}{{ bsd }} svm_service: {{ host }} {{ time }} GMT : GUI CMD_EXECUTED : User nsroot - Remote_ip 10.1.1.1 - Command "login login tenant_name=Owner,password=***********,challenge_response=***********,token=1c81504d124245d,client_port=-1,cert_verified=false,sessionid=***********,session_timeout=900,permission=superuser" - Status "Done"\n'
+        '{{ mark }}{{ bsd }} svm_service: {{ host }}  {{ time }} GMT mynetscaler2 0-PPE-0 : GUI CMD_EXECUTED : User nsroot - Remote_ip 10.1.1.1 - Command "login login tenant_name=Owner,password=***********,challenge_response=***********,token=1c81504d124245d,client_port=-1,cert_verified=false,sessionid=***********,session_timeout=900,permission=superuser" - Status "Done"\n'
     )
     message = mt.render(
         mark="<12>", bsd=bsd, time=time, tzname=tzname, host=host, pid=pid


### PR DESCRIPTION
* Updated the filter for Citrix NetScaler Syslog event.
* Updated the filter criteria for `citrix:netscaler:appfw` sourcetype to correctly map the events to the respective sourcetype as below (similar to  [PR #1862](https://github.com/splunk/splunk-connect-for-syslog/pull/1862))

Below is an example of the Syslog event for which the filter has been updated:

<pre><134>Jun 18 18:18:42 svm_service: 1.1.1.1  18/06/2020:16:18:42 GMT mynetscaler2 0-PPE-0 : GUI CMD_EXECUTED : User nsroot - Remote_ip 10.55.1.100 - Command "login login tenant_name=Owner,password=***********,challenge_response=***********,token=1c81504d124245d,client_port=-1,cert_verified=false,sessionid=***********,session_timeout=900,permission=superuser" - Status "Done"</pre>