### PR TITLE
feat: key fixed and debug mode reinstated

### DIFF
--- a/package/etc/conf.d/log_paths/0/lp_dest_filtered_alts_select/plugin.jinja
+++ b/package/etc/conf.d/log_paths/0/lp_dest_filtered_alts_select/plugin.jinja
@@ -6,7 +6,8 @@ log{
         # SC4S_DEST_SPECTRACOM_XXX_ALT_FILTER="f_is_rfc3dfsfs"
         # SC4S_DEST_SPECTRACOM_XXX_FILTERED_ALTERNATES="d_hec_debug"
 
-        '{{ dest_key }}' eq "${fields.sc4s_vendor}_${fields.sc4s_product}"
+        ('{{ dest_key }}' eq "${fields.sc4s_vendor}_${fields.sc4s_product}") or 
+        ('{{ lower_dest_key }}' eq "${fields.sc4s_vendor}_${fields.sc4s_product}") 
 
     };
     {% for f in filters %}

--- a/package/etc/conf.d/log_paths/0/lp_dest_filtered_alts_select/plugin.py
+++ b/package/etc/conf.d/log_paths/0/lp_dest_filtered_alts_select/plugin.py
@@ -17,6 +17,7 @@ for var in os.environ:
     filters = {}
     if var.startswith("SC4S_DEST_") and var.endswith("_FILTERED_ALTERNATES"):
         dest_key = var.replace("SC4S_DEST_", "").replace("_FILTERED_ALTERNATES", "")
+        lower_dest_key = dest_key.lower()
         dest_key_dests = os.environ[var].split(",")
         dest_filters = os.getenv(
             f"SC4S_DEST_{ dest_key }_ALT_FILTER", "f_is_nevermatch"
@@ -36,5 +37,5 @@ for var in os.environ:
                 filters[f].append(d)
             else:
                 filters[f] = [d]
-        msg = tm.render(dest_key=dest_key, filters=filters)
+        msg = tm.render(dest_key=dest_key, filters=filters, lower_dest_key=lower_dest_key)
         print(msg)


### PR DESCRIPTION
Closes #1897 
The debug mode can be enabled e.g. for cisco_asa messages by setting following property
SC4S_DEST_CISCO_ASA_FILTERED_ALTERNATES=d_hec_debug
SC4S_DEST_CISCO_ASA_ALT_FILTER=f_is_rfc3164