### PR TITLE
fix: vmware_vsphere sourcetype program matches (#1959)

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-vmware_vsphere.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-vmware_vsphere.conf
@@ -23,7 +23,8 @@ filter syslog-vmware_vsphere-esx-pgm{
     or program("crond", type(string) flags(ignore-case,prefix))
     or program("kmxa", type(string) flags(ignore-case,prefix))
     or program("crx-cli", type(string) flags(ignore-case,prefix))
-    or program("backup.sh*", type(string) flags(ignore-case,prefix))
+    or program("backup.sh", type(string) flags(ignore-case,prefix))
+    or program("auto-backup.sh", type(string) flags(ignore-case,prefix))
     or program("configStoreBackup", type(string) flags(ignore-case,prefix))
     or program("heartbeat", type(string) flags(ignore-case,prefix))
 
@@ -31,6 +32,7 @@ filter syslog-vmware_vsphere-esx-pgm{
     or program("vmauthd", type(string) flags(ignore-case,prefix))
     or program("localcli", type(string) flags(ignore-case,prefix))
     or program("watchdog-vsanperfsvc", type(string) flags(ignore-case,prefix))
+    or program("watchdog-iofiltervpd", type(string) flags(ignore-case,prefix))
     or program("apiForwarder", type(string) flags(ignore-case,prefix))
     or program("tmpwatch", type(string) flags(ignore-case,prefix))
     or program(".etc.init.d.vsanmgmtd", type(string) flags(ignore-case,prefix))

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -475,7 +475,7 @@ def test_cisco_esa_cef1(record_property, setup_wordlist, setup_splunk, setup_sc4
     assert resultCount == 1
 
 def test_cisco_esa_cef2(record_property, setup_wordlist, setup_splunk, setup_sc4s):
-    host = "cisco-esa"
+    host = "cisco-esa_1"
 
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)


### PR DESCRIPTION
* vmware_vsphere: fix sourcetype program matches

remove * from backup, type(string) does not interpret it as a wildcard, but instead as a string.

Add match for auto-backup.sh program

* vmware_vsphere: add watchdog-iofiltervpd sourcetype