### PR TITLE
Preparation/minor fixes for the syslog-ng v4 upgrade

### DIFF
--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
@@ -39,6 +39,7 @@ block parser app-postfilter-cisco_acs() {
                     inherit-mode(context)
                 )
                 timeout(10)
+                persist-name("grouping-by-app-postfilter-cisco_acs")
             );
         };
 
@@ -59,7 +60,6 @@ application app-postfilter-cisco_acs[sc4s-postfilter] {
 	filter {
         program('CSCOacs' type(string) flags(prefix))
         and "${.values.num}" > "1";
-    };	
+    };
     parser { app-postfilter-cisco_acs(); };
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
@@ -38,6 +38,7 @@ block parser app-postfilter-cisco_ise() {
                     inherit-mode(context)
                 )
                 timeout(10)
+                persist-name("grouping-by-app-postfilter-cisco_ise")
             );
         };
 
@@ -58,7 +59,6 @@ application app-postfilter-cisco_ise[sc4s-postfilter] {
 	filter {
         program('CISE_' type(string) flags(prefix))
         and "${.values.num}" ne "1";
-    };	
+    };
     parser { app-postfilter-cisco_ise(); };
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_invalidmultiline.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_invalidmultiline.conf
@@ -28,6 +28,7 @@ block parser app-postfilter-vmware_vsphere_invalidmultiline() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_invalidmultiline")
             );
         };
 

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_sdrsInjector.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_sdrsInjector.conf
@@ -28,6 +28,7 @@ block parser app-postfilter-vmware_vsphere_sdrsInjector() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_sdrsInjector")
             );
         };
 

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_storageRM.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_storageRM.conf
@@ -29,6 +29,7 @@ block parser app-postfilter-vmware_vsphere_storageRM() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_storageRM")
             );
         };
 

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -3,6 +3,7 @@
 import sys
 import traceback
 import re
+
 try:
     import syslogng
 except:
@@ -15,13 +16,14 @@ regex = r"\"([^\"]+)\"=\"([^\"]+)\""
 # matches = re.finditer(regex, test_str, re.MULTILINE)
 
 # for matchNum, match in enumerate(matches, start=1):
-    
+
 #     print ("Match {matchNum} was found at {start}-{end}: {match}".format(matchNum = matchNum, start = match.start(), end = match.end(), match = match.group()))
-    
+
 #     for groupNum in range(0, len(match.groups())):
 #         groupNum = groupNum + 1
-        
+
 #         print ("Group {groupNum} found at {start}-{end}: {group}".format(groupNum = groupNum, start = match.start(groupNum), end = match.end(groupNum), group = match.group(groupNum)))
+
 
 class kvqf_parse(object):
     def init(self, options):
@@ -33,15 +35,17 @@ class kvqf_parse(object):
 
     def parse(self, log_message):
         try:
-            matches = re.finditer(regex, log_message[".tmp.pairs"].decode("utf-8"), re.MULTILINE)
+            matches = re.finditer(
+                regex, log_message[".tmp.pairs"].decode("utf-8"), re.MULTILINE
+            )
             for matchNum, match in enumerate(matches, start=1):
                 k = match.groups()[0]
                 v = match.groups()[1]
-                log_message[f".values.{k}"]=v
+                log_message[f".values.{k}"] = v
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug(f'kvqf_parse.parse complete')
+        self.logger.debug(f"kvqf_parse.parse complete")
         return True

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -30,9 +30,6 @@ class kvqf_parse(object):
         self.logger = syslogng.Logger()
         return True
 
-    def deinit(self):
-        self.db.close()
-
     def parse(self, log_message):
         try:
             matches = re.finditer(


### PR DESCRIPTION
I've started testing [splunk-connect-for-syslog](https://github.com/splunk/splunk-connect-for-syslog) with syslog-ng v4.

This PR is the result of my tests, it makes SC4S operable with syslog-ng 4.

There are quite a few warnings that need to be fixed before upgrading to v4, but I'd submit them in a separate pull request.