### PR TITLE
syslog-ng v4.2 upgrade

### DIFF
--- a/package/etc/conf.d/conflib/_common/p_date-parser_nofilter.conf
+++ b/package/etc/conf.d/conflib/_common/p_date-parser_nofilter.conf
@@ -33,8 +33,8 @@ block parser date-parser-alts-nofilter(
                 flags(guess-timezone));
             };
             filter {
-                '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' < "43200"
-                and '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' > "-43200"
+                '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' < 43200
+                and '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' > -43200
             };
         } elif {
             parser {
@@ -42,8 +42,8 @@ block parser date-parser-alts-nofilter(
                 flags(guess-timezone));
             };
             filter {
-                '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' < "43200"
-                and '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' > "-43200"
+                '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' < 43200
+                and '$(round $(- "$S_UNIXTIME" "$R_UNIXTIME"))' > -43200
             };
         } else {
             rewrite { set("dtparse: Expected: `fmt_one` OR `fmt_two`; Actual: `template`" value("fields.sc4s_error")); };

--- a/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_event.conf
+++ b/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_event.conf
@@ -7,18 +7,18 @@ def splunk_hec_metric_event(log_message):
         logger.debug(log_message)
 
         m = {}
-        m['time']=log_message['S_UNIXTIME'].decode("utf-8")
-        m['host']=log_message['HOST'].decode("utf-8").lower()
-        m['source']=log_message['.splunk.source'].decode("utf-8")
-        m['sourcetype']=log_message['.splunk.sourcetype'].decode("utf-8")
-        m['index']=log_message['.splunk.index'].decode("utf-8")
+        m['time']=log_message.get_as_str('S_UNIXTIME', '', repr='internal')
+        m['host']=log_message.get_as_str('HOST', '').lower()
+        m['source']=log_message.get_as_str('.splunk.source', '')
+        m['sourcetype']=log_message.get_as_str('.splunk.sourcetype', '')
+        m['index']=log_message.get_as_str('.splunk.index', '')
         m['fields']={}
         for field in log_message.keys():
             dfield = field.decode("utf-8")
             if dfield.startswith('fields.'):
                     sfield=dfield[7:]
-                    m['fields'][sfield]=log_message[field].decode("utf-8")
-        rawmetrics = log_message['MESSAGE'].decode("utf-8").rstrip(", ").split(", ")
+                    m['fields'][sfield]=log_message.get_as_str(field, '', repr='internal')
+        rawmetrics = log_message.get_as_str('MESSAGE', '').rstrip(", ").split(", ")
 
         metrics = {}
         metriclist = []

--- a/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_multi.conf
+++ b/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_multi.conf
@@ -9,18 +9,18 @@ def splunk_hec_metric_multi(log_message):
         output = StringIO()
 
         m = {}
-        m['time']=log_message['S_UNIXTIME'].decode("utf-8")
-        m['host']=log_message['HOST'].decode("utf-8").lower()
-        m['source']=log_message['.splunk.source'].decode("utf-8")
-        m['sourcetype']=log_message['.splunk.sourcetype'].decode("utf-8")
-        m['index']=log_message['.splunk.index'].decode("utf-8")
+        m['time']=log_message.get_as_str('S_UNIXTIME', '', repr='internal')
+        m['host']=log_message.get_as_str('HOST', '').lower()
+        m['source']=log_message.get_as_str('.splunk.source', '')
+        m['sourcetype']=log_message.get_as_str('.splunk.sourcetype', '')
+        m['index']=log_message.get_as_str('.splunk.index', '')
         m['fields']={}
         for field in log_message.keys():
             dfield = field.decode("utf-8")
             if dfield.startswith('fields.'):
                     sfield=dfield[7:]
-                    m['fields'][sfield]=log_message[field].decode("utf-8")
-        rawmetrics = log_message['MESSAGE'].decode("utf-8").rstrip(", ").split(", ")
+                    m['fields'][sfield]=log_message.get_as_str(field, '', repr='internal')
+        rawmetrics = log_message.get_as_str('MESSAGE', '').rstrip(", ").split(", ")
 
         metricset = {}
         metrics = {}

--- a/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_multi_v2.conf
+++ b/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_multi_v2.conf
@@ -10,9 +10,7 @@ def splunk_hec_metric_multi_v2(log_message):
         logger.debug(log_message)
         output = StringIO()
 
-
-
-        rawmetrics = log_message['MESSAGE'].decode("utf-8").rstrip(", ").split(", ")
+        rawmetrics = log_message.get_as_str('MESSAGE', '').rstrip(", ").split(", ")
 
         metricset = {}
 
@@ -97,18 +95,18 @@ def splunk_hec_metric_multi_v2(log_message):
 
                 if mk not in metricset:
                         metricset[mk]={}
-                        metricset[mk]['time']=log_message['S_UNIXTIME'].decode("utf-8")
-                        metricset[mk]['host']=log_message['HOST'].decode("utf-8").lower()
-                        metricset[mk]['source']=log_message['.splunk.source'].decode("utf-8")
-                        metricset[mk]['sourcetype']=log_message['.splunk.sourcetype'].decode("utf-8")
-                        metricset[mk]['index']=log_message['.splunk.index'].decode("utf-8")
+                        metricset[mk]['time']=log_message.get_as_str('S_UNIXTIME', '', repr='internal')
+                        metricset[mk]['host']=log_message.get_as_str('HOST', '').lower()
+                        metricset[mk]['source']=log_message.get_as_str('.splunk.source', '')
+                        metricset[mk]['sourcetype']=log_message.get_as_str('.splunk.sourcetype', '')
+                        metricset[mk]['index']=log_message.get_as_str('.splunk.index', '')
                         metricset[mk]['fields']={}
 
                         for field in log_message.keys():
                                 dfield = field.decode("utf-8")
                                 if dfield.startswith('fields.'):
                                         sfield=dfield[7:]
-                                        metricset[mk]['fields'][sfield]=log_message[field].decode("utf-8")
+                                        metricset[mk]['fields'][sfield]=log_message.get_as_str(field, '', repr='internal')
 
                 for k,v in dims.items():
                         metricset[mk]['fields'][k]=v

--- a/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_single.conf
+++ b/package/etc/conf.d/conflib/_common/t_splunk_hec_metric_single.conf
@@ -10,21 +10,21 @@ def splunk_hec_metric_single(log_message):
         output = StringIO()
 
         mb = {}
-        mb['time']=log_message['S_UNIXTIME'].decode("utf-8")
-        mb['host']=log_message['HOST'].decode("utf-8").lower()
-        mb['source']=log_message['.splunk.source'].decode("utf-8")
-        mb['sourcetype']=log_message['.splunk.sourcetype'].decode("utf-8")
-        mb['index']=log_message['.splunk.index'].decode("utf-8")
+        mb['time']=log_message.get_as_str('S_UNIXTIME', '', repr='internal')
+        mb['host']=log_message.get_as_str('HOST', '').lower()
+        mb['source']=log_message.get_as_str('.splunk.source', '')
+        mb['sourcetype']=log_message.get_as_str('.splunk.sourcetype', '')
+        mb['index']=log_message.get_as_str('.splunk.index', '')
         mb['fields']={}
         for field in log_message.keys():
             dfield = field.decode("utf-8")
             if dfield.startswith('fields.'):
                     sfield=dfield[7:]
-                    mb['fields'][sfield]=log_message[field].decode("utf-8")
+                    mb['fields'][sfield]=log_message.get_as_str(field, '', repr='internal')
 
 
 
-        rawmetrics = log_message['MESSAGE'].decode("utf-8").rstrip(", ").split(", ")
+        rawmetrics = log_message.get_as_str('MESSAGE', '').rstrip(", ").split(", ")
         feed = False
         for rm in rawmetrics:
 

--- a/package/etc/conf.d/conflib/_splunk/splunkfields.conf
+++ b/package/etc/conf.d/conflib/_splunk/splunkfields.conf
@@ -14,9 +14,9 @@ rewrite r_set_splunk_default {
             set($R_UNIXTIME, value("fields.sc4s_recv_time") condition(match('r_unixtime' template('`SC4S_DEST_SPLUNK_INDEXED_FIELDS`') type(string) flags(substring)) ));
         };
 
-        if (match("6" value("PROTO"))) {
+        if ("$PROTO" == 6) {
             rewrite { set("TCP", value("fields.sc4s_proto") condition(match('proto' template('`SC4S_DEST_SPLUNK_INDEXED_FIELDS`') type(string) flags(substring)) )); };
-        } elif (match("17" value("PROTO"))) {
+        } elif ("$PROTO" == 17) {
             rewrite { set("UDP", value("fields.sc4s_proto") condition(match('proto' template('`SC4S_DEST_SPLUNK_INDEXED_FIELDS`') type(string) flags(substring)) )); };
         } else {
             rewrite { set($PROTO, value("fields.sc4s_proto") condition(match('proto' template('`SC4S_DEST_SPLUNK_INDEXED_FIELDS`') type(string) flags(substring)) )); };
@@ -128,4 +128,3 @@ filter f_is_source_identified{
 filter f_is_agg{
     tags("agg");
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-beyondtrust_sra.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-beyondtrust_sra.conf
@@ -37,8 +37,7 @@ block parser app-postfilter-beyondtrust_sra() {
 application app-postfilter-beyondtrust_sra[sc4s-postfilter] {
 	filter {
         program('BG' type(string))
-        and "${.metadata.sc4s.countOfParts}" > "1";
-    };	
+        and "${.metadata.sc4s.countOfParts}" > 1;
+    };
     parser { app-postfilter-beyondtrust_sra(); };
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-checkpoint_splunk_02-group.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-checkpoint_splunk_02-group.conf
@@ -5,7 +5,7 @@ block parser app-postfilter-checkpoint_splunk_02-group() {
                 key("${.values.loguid}")
                 #This looks silly but we have no way of knowing if an event is complete so
                 #We must make an impossible condition and rely on time out
-                trigger("1" == "2")
+                trigger(1 == 2)
                 aggregate(
                     tags("agg")
                     inherit-mode(last-message)
@@ -27,6 +27,6 @@ application app-postfilter-checkpoint_splunk_02-group[sc4s-postfilter] {
         and match('splunk', value('fields.sc4s_product') type(string))
         and "`SC4S_LISTEN_CHECKPOINT_SPLUNK_NOISE_CONTROL`" eq "yes"
         and "${.values.loguid}" ne "";
-    };	
+    };
     parser { app-postfilter-checkpoint_splunk_02-group(); };
 };

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-checkpoint_syslog_02-group.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-checkpoint_syslog_02-group.conf
@@ -6,7 +6,7 @@ block parser app-postfilter-checkpoint_syslog_02-group() {
                 key("${.SDATA.sc4s@2620.loguid}")
                 #This looks silly but we have no way of knowing if an event is complete so
                 #We must make an impossible condition and rely on time out
-                trigger("1" == "2")
+                trigger(1 == 2)
                 aggregate(
                     tags("agg")
                     inherit-mode(last-message)
@@ -27,6 +27,6 @@ application app-postfilter-checkpoint_syslog_02-group[sc4s-postfilter] {
         program('CheckPoint' type(string))
         and "`SC4S_LISTEN_CHECKPOINT_SPLUNK_NOISE_CONTROL`" eq "yes"
         and "${.SDATA.sc4s@2620.loguid}" ne "";
-    };	
+    };
     parser { app-postfilter-checkpoint_syslog_02-group(); };
 };

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
@@ -39,6 +39,7 @@ block parser app-postfilter-cisco_acs() {
                     inherit-mode(context)
                 )
                 timeout(10)
+                persist-name("grouping-by-app-postfilter-cisco_acs")
             );
         };
 
@@ -59,7 +60,6 @@ application app-postfilter-cisco_acs[sc4s-postfilter] {
 	filter {
         program('CSCOacs' type(string) flags(prefix))
         and "${.values.num}" > "1";
-    };	
+    };
     parser { app-postfilter-cisco_acs(); };
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_acs.conf
@@ -59,7 +59,7 @@ block parser app-postfilter-cisco_acs() {
 application app-postfilter-cisco_acs[sc4s-postfilter] {
 	filter {
         program('CSCOacs' type(string) flags(prefix))
-        and "${.values.num}" > "1";
+        and "${.values.num}" > 1;
     };
     parser { app-postfilter-cisco_acs(); };
 };

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
@@ -58,7 +58,7 @@ block parser app-postfilter-cisco_ise() {
 application app-postfilter-cisco_ise[sc4s-postfilter] {
 	filter {
         program('CISE_' type(string) flags(prefix))
-        and "${.values.num}" ne "1";
+        and "${.values.num}" != 1;
     };
     parser { app-postfilter-cisco_ise(); };
 };

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-cisco_ise.conf
@@ -38,6 +38,7 @@ block parser app-postfilter-cisco_ise() {
                     inherit-mode(context)
                 )
                 timeout(10)
+                persist-name("grouping-by-app-postfilter-cisco_ise")
             );
         };
 
@@ -58,7 +59,6 @@ application app-postfilter-cisco_ise[sc4s-postfilter] {
 	filter {
         program('CISE_' type(string) flags(prefix))
         and "${.values.num}" ne "1";
-    };	
+    };
     parser { app-postfilter-cisco_ise(); };
 };
-

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_invalidmultiline.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_invalidmultiline.conf
@@ -28,6 +28,7 @@ block parser app-postfilter-vmware_vsphere_invalidmultiline() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_invalidmultiline")
             );
         };
 

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_sdrsInjector.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_sdrsInjector.conf
@@ -28,6 +28,7 @@ block parser app-postfilter-vmware_vsphere_sdrsInjector() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_sdrsInjector")
             );
         };
 

--- a/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_storageRM.conf
+++ b/package/etc/conf.d/conflib/post-filter/app-postfilter-vmware_vsphere_storageRM.conf
@@ -29,6 +29,7 @@ block parser app-postfilter-vmware_vsphere_storageRM() {
                     inherit-mode(context)
                 )
                 timeout(2)
+                persist-name("grouping-by-app-postfilter-vmware_vsphere_storageRM")
             );
         };
 

--- a/package/etc/conf.d/conflib/syslog/app-syslog-beyondtrust_sra.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-beyondtrust_sra.conf
@@ -24,7 +24,7 @@ block parser app-syslog-beyondtrust_sra() {
         rewrite {
             set('${.tmp.siteid}' value('.values.siteid'));
             set('${.tmp.seq}' value('.values.seq'));
-            set('${.tmp.num}' value('.metadata.sc4s.countOfParts'));
+            set(int("${.tmp.num}") value('.metadata.sc4s.countOfParts'));
             set('${.tmp.message}' value('.message'));
         };
    };
@@ -32,7 +32,7 @@ block parser app-syslog-beyondtrust_sra() {
 application app-syslog-beyondtrust_sra[sc4s-syslog-pgm] {
 	filter {
         "${PROGRAM}" eq "BG"
-    };	
+    };
     parser { app-syslog-beyondtrust_sra(); };
 };
 

--- a/package/etc/conf.d/conflib/syslog/app-syslog-cisco_acs.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-cisco_acs.conf
@@ -27,6 +27,10 @@ block parser app-syslog-cisco_acs() {
             );
         };
 
+        rewrite {
+            set(int("${.values.num:-0}") value(".values.num"));
+        };
+
         if {
             filter {"${.values.seq}" eq "0"};
             parser(p_acs_event_time);
@@ -47,7 +51,6 @@ block parser app-syslog-cisco_acs() {
 application app-syslog-cisco_acs[sc4s-syslog-pgm] {
 	filter {
         program('CSCOacs' type(string) flags(prefix));
-    };	
+    };
     parser { app-syslog-cisco_acs(); };
 };
-

--- a/package/etc/conf.d/conflib/syslog/app-syslog-cisco_ise.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-cisco_ise.conf
@@ -27,6 +27,10 @@ block parser app-syslog-cisco_ise() {
             );
         };
 
+        rewrite {
+            set(int("${.values.num:-0}") value(".values.num"));
+        };
+
         if {
             filter {"${.values.seq}" eq "0"};
             parser(ise_event_time);
@@ -47,7 +51,6 @@ block parser app-syslog-cisco_ise() {
 application app-syslog-cisco_ise[sc4s-syslog-pgm] {
 	filter {
         program('CISE_' type(string) flags(prefix));
-    };	
+    };
     parser { app-syslog-cisco_ise(); };
 };
-

--- a/package/etc/conf.d/sc4slib/global_options/plugin.jinja
+++ b/package/etc/conf.d/sc4slib/global_options/plugin.jinja
@@ -11,9 +11,11 @@ options {
         keep-hostname (yes);
         create_dirs(yes);
         dir_perm(0750);
-        stats-freq ({{ stats_freq }});
-        stats_level ({{ stats_level }});
-        stats-max-dynamics(2000);
+        stats (
+                freq ({{ stats_freq }})
+                level ({{ stats_level }})
+                max-dynamics(2000)
+        );
         normalize-hostnames(yes);
         on-error(fallback-to-string);
         frac-digits(3);

--- a/package/etc/pylib/parser_cef.py
+++ b/package/etc/pylib/parser_cef.py
@@ -4,11 +4,14 @@ import traceback
 
 try:
     import syslogng
+    from syslogng import LogParser
 except:
-    pass
+
+    class LogParser:
+        pass
 
 
-class cef_kv(syslogng.LogParser):
+class cef_kv(LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         return True

--- a/package/etc/pylib/parser_cef.py
+++ b/package/etc/pylib/parser_cef.py
@@ -7,6 +7,7 @@ try:
 except:
     pass
 
+
 class cef_kv(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
@@ -15,7 +16,7 @@ class cef_kv(syslogng.LogParser):
     def parse(self, log_message):
 
         try:
-            data = log_message[".metadata.cef.ext"].decode("utf-8")
+            data = log_message.get_as_str(".metadata.cef.ext", "")
 
             rpairs = re.findall(r"([^=\s]+)=((?:[\\]=|[^=])+)(?:\s|$)", data)
             pairs = {}

--- a/package/etc/pylib/parser_cef.py
+++ b/package/etc/pylib/parser_cef.py
@@ -7,7 +7,7 @@ try:
 except:
     pass
 
-class cef_kv(object):
+class cef_kv(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         return True

--- a/package/etc/pylib/parser_cef.py
+++ b/package/etc/pylib/parser_cef.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import traceback
+
 try:
     import syslogng
 except:
@@ -16,35 +17,34 @@ class cef_kv(object):
         try:
             data = log_message[".metadata.cef.ext"].decode("utf-8")
 
-            rpairs = re.findall(r'([^=\s]+)=((?:[\\]=|[^=])+)(?:\s|$)', data)
-            pairs={}
-            keys=[]
+            rpairs = re.findall(r"([^=\s]+)=((?:[\\]=|[^=])+)(?:\s|$)", data)
+            pairs = {}
+            keys = []
             for p in rpairs:
-                pairs[p[0]]=p[1]
+                pairs[p[0]] = p[1]
                 keys.append(p[0])
 
-
-            cleanpairs={}
+            cleanpairs = {}
             for k in keys:
-                if k.endswith('Label'):
-                    vk=k.rstrip('Label')
+                if k.endswith("Label"):
+                    vk = k.rstrip("Label")
                     if k in pairs:
                         l = pairs[k]
                         if vk in pairs:
-                            pairs[l]=pairs[vk]
+                            pairs[l] = pairs[vk]
                             del pairs[vk]
                         del pairs[k]
-                elif k == 'rawEvent':
-                    pairs[k]=pairs[k].replace('\=','=').replace('&&','\n')
+                elif k == "rawEvent":
+                    pairs[k] = pairs[k].replace("\=", "=").replace("&&", "\n")
 
-            for k,v in pairs.items():
-                kc = k.replace(' ','_').replace('.','_')
-                log_message[f".values.{kc}"]=v
+            for k, v in pairs.items():
+                kc = k.replace(" ", "_").replace(".", "_")
+                log_message[f".values.{kc}"] = v
 
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-            self.logger.debug(f'kvqf_parse.parse complete')
+            self.logger.debug(f"kvqf_parse.parse complete")
         return True

--- a/package/etc/pylib/parser_fix_dns.py
+++ b/package/etc/pylib/parser_fix_dns.py
@@ -11,6 +11,7 @@ try:
 except:
     pass
 
+
 class FixHostResolver(syslogng.LogParser):
     def parse(self, log_message):
         """
@@ -19,7 +20,7 @@ class FixHostResolver(syslogng.LogParser):
 
         # try to resolve the IP address
         try:
-            ipaddr = log_message["SOURCEIP"].decode("utf-8")
+            ipaddr = log_message.get_as_str("SOURCEIP", "", repr="internal")
 
             hostname, aliaslist, ipaddrlist = socket.gethostbyaddr(ipaddr)
             # print(ipaddr)

--- a/package/etc/pylib/parser_fix_dns.py
+++ b/package/etc/pylib/parser_fix_dns.py
@@ -6,8 +6,12 @@ value pair names are hard-coded
 import re
 import socket
 
+try:
+    import syslogng
+except:
+    pass
 
-class FixHostResolver(object):
+class FixHostResolver(syslogng.LogParser):
     def parse(self, log_message):
         """
         Resolves IP to hostname

--- a/package/etc/pylib/parser_fix_dns.py
+++ b/package/etc/pylib/parser_fix_dns.py
@@ -8,11 +8,14 @@ import socket
 
 try:
     import syslogng
+    from syslogng import LogParser
 except:
-    pass
+
+    class LogParser:
+        pass
 
 
-class FixHostResolver(syslogng.LogParser):
+class FixHostResolver(LogParser):
     def parse(self, log_message):
         """
         Resolves IP to hostname

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -6,8 +6,12 @@ import re
 
 try:
     import syslogng
+    from syslogng import LogParser
 except:
-    pass
+
+    class LogParser:
+        pass
+
 
 regex = r"\"([^\"]+)\"=\"([^\"]+)\""
 
@@ -25,7 +29,7 @@ regex = r"\"([^\"]+)\"=\"([^\"]+)\""
 #         print ("Group {groupNum} found at {start}-{end}: {group}".format(groupNum = groupNum, start = match.start(groupNum), end = match.end(groupNum), group = match.group(groupNum)))
 
 
-class kvqf_parse(syslogng.LogParser):
+class kvqf_parse(LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         return True

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -3,6 +3,7 @@
 import sys
 import traceback
 import re
+
 try:
     import syslogng
 except:
@@ -15,13 +16,14 @@ regex = r"\"([^\"]+)\"=\"([^\"]+)\""
 # matches = re.finditer(regex, test_str, re.MULTILINE)
 
 # for matchNum, match in enumerate(matches, start=1):
-    
+
 #     print ("Match {matchNum} was found at {start}-{end}: {match}".format(matchNum = matchNum, start = match.start(), end = match.end(), match = match.group()))
-    
+
 #     for groupNum in range(0, len(match.groups())):
 #         groupNum = groupNum + 1
-        
+
 #         print ("Group {groupNum} found at {start}-{end}: {group}".format(groupNum = groupNum, start = match.start(groupNum), end = match.end(groupNum), group = match.group(groupNum)))
+
 
 class kvqf_parse(object):
     def init(self, options):
@@ -33,15 +35,17 @@ class kvqf_parse(object):
 
     def parse(self, log_message):
         try:
-            matches = re.finditer(regex, log_message[".tmp.pairs"].decode("utf-8"), re.MULTILINE)
+            matches = re.finditer(
+                regex, log_message[".tmp.pairs"].decode("utf-8"), re.MULTILINE
+            )
             for matchNum, match in enumerate(matches, start=1):
                 k = match.groups()[0]
                 v = match.groups()[1]
-                log_message[f".values.{k}"]=v
+                log_message[f".values.{k}"] = v
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug(f'kvqf_parse.parse complete')
+        self.logger.debug(f"kvqf_parse.parse complete")
         return True

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -33,7 +33,7 @@ class kvqf_parse(syslogng.LogParser):
     def parse(self, log_message):
         try:
             matches = re.finditer(
-                regex, log_message[".tmp.pairs"].decode("utf-8"), re.MULTILINE
+                regex, log_message.get_as_str(".tmp.pairs", ""), re.MULTILINE
             )
             for matchNum, match in enumerate(matches, start=1):
                 k = match.groups()[0]

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -30,9 +30,6 @@ class kvqf_parse(object):
         self.logger = syslogng.Logger()
         return True
 
-    def deinit(self):
-        self.db.close()
-
     def parse(self, log_message):
         try:
             matches = re.finditer(

--- a/package/etc/pylib/parser_kvqf.py
+++ b/package/etc/pylib/parser_kvqf.py
@@ -25,7 +25,7 @@ regex = r"\"([^\"]+)\"=\"([^\"]+)\""
 #         print ("Group {groupNum} found at {start}-{end}: {group}".format(groupNum = groupNum, start = match.start(groupNum), end = match.end(groupNum), group = match.group(groupNum)))
 
 
-class kvqf_parse(object):
+class kvqf_parse(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         return True

--- a/package/etc/pylib/parser_leef.py
+++ b/package/etc/pylib/parser_leef.py
@@ -8,7 +8,7 @@ try:
 except:
     pass
 
-class leef_kv(object):
+class leef_kv(syslogng.LogParser):
     def init(self, options):
         self.regex = r"( ?(?:[A-Z]{2,4}T|HAEC|IDLW|MSK|NT|UTC|THA))"
         self.logger = syslogng.Logger()

--- a/package/etc/pylib/parser_leef.py
+++ b/package/etc/pylib/parser_leef.py
@@ -5,11 +5,14 @@ import traceback
 
 try:
     import syslogng
+    from syslogng import LogParser
 except:
-    pass
+
+    class LogParser:
+        pass
 
 
-class leef_kv(syslogng.LogParser):
+class leef_kv(LogParser):
     def init(self, options):
         self.regex = r"( ?(?:[A-Z]{2,4}T|HAEC|IDLW|MSK|NT|UTC|THA))"
         self.logger = syslogng.Logger()

--- a/package/etc/pylib/parser_leef.py
+++ b/package/etc/pylib/parser_leef.py
@@ -8,6 +8,7 @@ try:
 except:
     pass
 
+
 class leef_kv(syslogng.LogParser):
     def init(self, options):
         self.regex = r"( ?(?:[A-Z]{2,4}T|HAEC|IDLW|MSK|NT|UTC|THA))"
@@ -17,7 +18,7 @@ class leef_kv(syslogng.LogParser):
     def parse(self, log_message):
 
         try:
-            msg = log_message["MESSAGE"].decode("utf-8")
+            msg = log_message.get_as_str("MESSAGE", "")
             # All LEEF message are | separated super structures
             structure = msg.split("|")
             # Indexed fields for Splunk

--- a/package/etc/pylib/parser_leef.py
+++ b/package/etc/pylib/parser_leef.py
@@ -2,6 +2,7 @@ import re
 import binascii
 import sys
 import traceback
+
 try:
     import syslogng
 except:

--- a/package/etc/pylib/parser_source_cache.py
+++ b/package/etc/pylib/parser_source_cache.py
@@ -1,4 +1,3 @@
-
 import sys
 import traceback
 import socket
@@ -6,6 +5,7 @@ import struct
 from sqlitedict import SqliteDict
 
 import time
+
 try:
     import syslogng
 except:
@@ -15,8 +15,10 @@ except:
 def ip2int(addr):
     return struct.unpack("!I", socket.inet_aton(addr))[0]
 
+
 def int2ip(addr):
     return socket.inet_ntoa(struct.pack("!I", addr))
+
 
 hostdict = str("/var/lib/syslog-ng/hostip")
 
@@ -33,28 +35,28 @@ class psc_parse(object):
         try:
             ipaddr = log_message["SOURCEIP"].decode("utf-8")
             ip_int = ip2int(ipaddr)
-            self.logger.debug(f'psc.parse sourceip={ipaddr} int={ip_int}')
+            self.logger.debug(f"psc.parse sourceip={ipaddr} int={ip_int}")
             name = self.db[ip_int]
-            self.logger.debug(f'psc.parse host={name}')
-            log_message["HOST"]=name
+            self.logger.debug(f"psc.parse host={name}")
+            log_message["HOST"] = name
 
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug(f'psc.parse complete')
+        self.logger.debug(f"psc.parse complete")
         return True
 
 class psc_dest(object):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:
-            self.db = SqliteDict(f"{hostdict}.sqlite",autocommit=True)
+            self.db = SqliteDict(f"{hostdict}.sqlite", autocommit=True)
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
         return True
 
@@ -67,28 +69,31 @@ class psc_dest(object):
         try:
             ipaddr = log_message["SOURCEIP"].decode("utf-8")
             ip_int = ip2int(ipaddr)
-            self.logger.debug(f'psc.send sourceip={ipaddr} int={ip_int} host={log_message["HOST"]}')
+            self.logger.debug(
+                f'psc.send sourceip={ipaddr} int={ip_int} host={log_message["HOST"]}'
+            )
             if ip_int in self.db:
                 current = self.db[ip_int]
                 if current != log_message["HOST"]:
-                    self.db[ip_int] =log_message["HOST"]
+                    self.db[ip_int] = log_message["HOST"]
             else:
-                self.db[ip_int] =log_message["HOST"]
+                self.db[ip_int] = log_message["HOST"]
 
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug('psc.send complete')
+        self.logger.debug("psc.send complete")
         return True
 
     def flush(self):
         self.db.commit()
         return True
 
+
 if __name__ == "__main__":
-    db = SqliteDict(f"{hostdict}.sqlite",autocommit=True)
-    db[0]="seed"
+    db = SqliteDict(f"{hostdict}.sqlite", autocommit=True)
+    db[0] = "seed"
     db.commit()
     db.close()

--- a/package/etc/pylib/parser_source_cache.py
+++ b/package/etc/pylib/parser_source_cache.py
@@ -8,8 +8,14 @@ import time
 
 try:
     import syslogng
+    from syslogng import LogParser, LogDestination
 except:
-    pass
+
+    class LogParser:
+        pass
+
+    class LogDestination:
+        pass
 
 
 def ip2int(addr):
@@ -23,7 +29,7 @@ def int2ip(addr):
 hostdict = str("/var/lib/syslog-ng/hostip")
 
 
-class psc_parse(syslogng.LogParser):
+class psc_parse(LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         self.db = SqliteDict(f"{hostdict}.sqlite")
@@ -50,7 +56,7 @@ class psc_parse(syslogng.LogParser):
         return True
 
 
-class psc_dest(syslogng.LogDestination):
+class psc_dest(LogDestination):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:

--- a/package/etc/pylib/parser_source_cache.py
+++ b/package/etc/pylib/parser_source_cache.py
@@ -22,6 +22,7 @@ def int2ip(addr):
 
 hostdict = str("/var/lib/syslog-ng/hostip")
 
+
 class psc_parse(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
@@ -33,7 +34,7 @@ class psc_parse(syslogng.LogParser):
 
     def parse(self, log_message):
         try:
-            ipaddr = log_message["SOURCEIP"].decode("utf-8")
+            ipaddr = log_message.get_as_str("SOURCEIP", "", repr="internal")
             ip_int = ip2int(ipaddr)
             self.logger.debug(f"psc.parse sourceip={ipaddr} int={ip_int}")
             name = self.db[ip_int]
@@ -47,6 +48,7 @@ class psc_parse(syslogng.LogParser):
             return False
         self.logger.debug(f"psc.parse complete")
         return True
+
 
 class psc_dest(syslogng.LogDestination):
     def init(self, options):
@@ -67,7 +69,7 @@ class psc_dest(syslogng.LogDestination):
 
     def send(self, log_message):
         try:
-            ipaddr = log_message["SOURCEIP"].decode("utf-8")
+            ipaddr = log_message.get_as_str("SOURCEIP", "", repr="internal")
             ip_int = ip2int(ipaddr)
             self.logger.debug(
                 f'psc.send sourceip={ipaddr} int={ip_int} host={log_message["HOST"]}'

--- a/package/etc/pylib/parser_source_cache.py
+++ b/package/etc/pylib/parser_source_cache.py
@@ -22,7 +22,7 @@ def int2ip(addr):
 
 hostdict = str("/var/lib/syslog-ng/hostip")
 
-class psc_parse(object):
+class psc_parse(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         self.db = SqliteDict(f"{hostdict}.sqlite")
@@ -48,7 +48,7 @@ class psc_parse(object):
         self.logger.debug(f"psc.parse complete")
         return True
 
-class psc_dest(object):
+class psc_dest(syslogng.LogDestination):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:

--- a/package/etc/pylib/parser_stealthbits.py
+++ b/package/etc/pylib/parser_stealthbits.py
@@ -2,13 +2,17 @@ import re
 
 try:
     import syslogng
+    from syslogng import LogParser
 except:
-    pass
+
+    class LogParser:
+        pass
+
 
 regex = r"^(.*[\.\!\?])?(.*:.*)"
 
 
-class alerttext_kv(syslogng.LogParser):
+class alerttext_kv(LogParser):
     def init(self, options):
         return True
 

--- a/package/etc/pylib/parser_stealthbits.py
+++ b/package/etc/pylib/parser_stealthbits.py
@@ -1,4 +1,5 @@
 import re
+
 try:
     import syslogng
 except:
@@ -6,17 +7,18 @@ except:
 
 regex = r"^(.*[\.\!\?])?(.*:.*)"
 
+
 class alerttext_kv(syslogng.LogParser):
     def init(self, options):
         return True
 
     def parse(self, log_message):
-        match = re.search(regex, log_message[".values.AlertText"].decode("utf-8"))
+        match = re.search(regex, log_message.get_as_str(".values.AlertText", ""))
         if match:
             log_message[".values.AlertText"] = match.groups()[0]
             text = match.groups()[1]
         else:
-            text = log_message[".values.AlertText"].decode("utf-8")
+            text = log_message.get_as_str(".values.AlertText", "")
             log_message[".values.AlertText"] = ""
 
         pairs = text.split("; ")

--- a/package/etc/pylib/parser_stealthbits.py
+++ b/package/etc/pylib/parser_stealthbits.py
@@ -1,8 +1,12 @@
 import re
+try:
+    import syslogng
+except:
+    pass
 
 regex = r"^(.*[\.\!\?])?(.*:.*)"
 
-class alerttext_kv(object):
+class alerttext_kv(syslogng.LogParser):
     def init(self, options):
         return True
 

--- a/package/etc/pylib/parser_stealthbits.py
+++ b/package/etc/pylib/parser_stealthbits.py
@@ -7,22 +7,20 @@ class alerttext_kv(object):
         return True
 
     def parse(self, log_message):
-        match  =  re.search(regex,log_message[".values.AlertText"].decode("utf-8"))
+        match = re.search(regex, log_message[".values.AlertText"].decode("utf-8"))
         if match:
-            log_message[".values.AlertText"]=match.groups()[0]
-            text=match.groups()[1]
+            log_message[".values.AlertText"] = match.groups()[0]
+            text = match.groups()[1]
         else:
             text = log_message[".values.AlertText"].decode("utf-8")
             log_message[".values.AlertText"] = ""
 
-        pairs = text.split('; ')
+        pairs = text.split("; ")
 
-
-        if len(pairs)==0:
+        if len(pairs) == 0:
             return False
         for p in pairs:
-            k,v=p.split(': ')
-            cleank=k.replace(' ','_').replace('.','_')
-            log_message[f".values.AlertTextValues.{cleank}"]=v.strip()
+            k, v = p.split(": ")
+            cleank = k.replace(" ", "_").replace(".", "_")
+            log_message[f".values.AlertTextValues.{cleank}"] = v.strip()
         return True
-

--- a/package/etc/pylib/parser_vps_cache.py
+++ b/package/etc/pylib/parser_vps_cache.py
@@ -14,6 +14,7 @@ except:
 
 hostdict = str("/var/lib/syslog-ng/vps")
 
+
 class vpsc_parse(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
@@ -25,7 +26,7 @@ class vpsc_parse(syslogng.LogParser):
 
     def parse(self, log_message):
         try:
-            host = log_message["HOST"].decode("utf-8")
+            host = log_message.get_as_str("HOST", "")
             self.logger.debug(f"vpsc.parse host={host}")
             fields = self.db[host]
             self.logger.debug(f"vpsc.parse host={host} fields={fields}")
@@ -39,6 +40,7 @@ class vpsc_parse(syslogng.LogParser):
             return False
         self.logger.debug(f"vpsc.parse complete")
         return True
+
 
 class vpsc_dest(syslogng.LogDestination):
     def init(self, options):
@@ -59,14 +61,14 @@ class vpsc_dest(syslogng.LogDestination):
 
     def send(self, log_message):
         try:
-            host = log_message["HOST"].decode("utf-8")
+            host = log_message.get_as_str("HOST", "")
             fields = {}
-            fields[".netsource.sc4s_vendor"] = log_message["fields.sc4s_vendor"].decode(
-                "utf-8"
+            fields[".netsource.sc4s_vendor"] = log_message.get_as_str(
+                "fields.sc4s_vendor"
             )
-            fields[".netsource.sc4s_product"] = log_message[
+            fields[".netsource.sc4s_product"] = log_message.get_as_str(
                 "fields.sc4s_product"
-            ].decode("utf-8")
+            )
 
             self.logger.debug(f"vpsc.send host={host} fields={fields}")
             if host in self.db:

--- a/package/etc/pylib/parser_vps_cache.py
+++ b/package/etc/pylib/parser_vps_cache.py
@@ -1,4 +1,3 @@
-
 import sys
 import traceback
 import socket
@@ -6,6 +5,7 @@ import struct
 from sqlitedict import SqliteDict
 
 import time
+
 try:
     import syslogng
 except:
@@ -26,29 +26,29 @@ class vpsc_parse(object):
     def parse(self, log_message):
         try:
             host = log_message["HOST"].decode("utf-8")
-            self.logger.debug(f'vpsc.parse host={host}')
+            self.logger.debug(f"vpsc.parse host={host}")
             fields = self.db[host]
-            self.logger.debug(f'vpsc.parse host={host} fields={fields}')
-            for k,v in fields.items():
-                log_message[k]=v
+            self.logger.debug(f"vpsc.parse host={host} fields={fields}")
+            for k, v in fields.items():
+                log_message[k] = v
 
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug(f'vpsc.parse complete')
+        self.logger.debug(f"vpsc.parse complete")
         return True
 
 class vpsc_dest(object):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:
-            self.db = SqliteDict(f"{hostdict}.sqlite",autocommit=True)
+            self.db = SqliteDict(f"{hostdict}.sqlite", autocommit=True)
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
         return True
 
@@ -60,11 +60,15 @@ class vpsc_dest(object):
     def send(self, log_message):
         try:
             host = log_message["HOST"].decode("utf-8")
-            fields={}
-            fields['.netsource.sc4s_vendor']=log_message["fields.sc4s_vendor"].decode("utf-8")
-            fields['.netsource.sc4s_product']=log_message["fields.sc4s_product"].decode("utf-8")
+            fields = {}
+            fields[".netsource.sc4s_vendor"] = log_message["fields.sc4s_vendor"].decode(
+                "utf-8"
+            )
+            fields[".netsource.sc4s_product"] = log_message[
+                "fields.sc4s_product"
+            ].decode("utf-8")
 
-            self.logger.debug(f'vpsc.send host={host} fields={fields}')
+            self.logger.debug(f"vpsc.send host={host} fields={fields}")
             if host in self.db:
                 current = self.db[host]
                 if current != fields:
@@ -75,14 +79,15 @@ class vpsc_dest(object):
         except:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            self.logger.debug(''.join('!! ' + line for line in lines))
+            self.logger.debug("".join("!! " + line for line in lines))
             return False
-        self.logger.debug('psc.send complete')
+        self.logger.debug("psc.send complete")
         return True
 
     def flush(self):
         self.db.commit()
         return True
+
 
 if __name__ == "__main__":
     pass

--- a/package/etc/pylib/parser_vps_cache.py
+++ b/package/etc/pylib/parser_vps_cache.py
@@ -14,7 +14,7 @@ except:
 
 hostdict = str("/var/lib/syslog-ng/vps")
 
-class vpsc_parse(object):
+class vpsc_parse(syslogng.LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         self.db = SqliteDict(f"{hostdict}.sqlite")
@@ -40,7 +40,7 @@ class vpsc_parse(object):
         self.logger.debug(f"vpsc.parse complete")
         return True
 
-class vpsc_dest(object):
+class vpsc_dest(syslogng.LogDestination):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:

--- a/package/etc/pylib/parser_vps_cache.py
+++ b/package/etc/pylib/parser_vps_cache.py
@@ -8,14 +8,20 @@ import time
 
 try:
     import syslogng
+    from syslogng import LogParser, LogDestination
 except:
-    pass
+
+    class LogParser:
+        pass
+
+    class LogDestination:
+        pass
 
 
 hostdict = str("/var/lib/syslog-ng/vps")
 
 
-class vpsc_parse(syslogng.LogParser):
+class vpsc_parse(LogParser):
     def init(self, options):
         self.logger = syslogng.Logger()
         self.db = SqliteDict(f"{hostdict}.sqlite")
@@ -42,7 +48,7 @@ class vpsc_parse(syslogng.LogParser):
         return True
 
 
-class vpsc_dest(syslogng.LogDestination):
+class vpsc_dest(LogDestination):
     def init(self, options):
         self.logger = syslogng.Logger()
         try:

--- a/package/etc/syslog-ng.conf
+++ b/package/etc/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version:3.36
+@version: 4.2
 
 # syslog-ng configuration file.
 


### PR DESCRIPTION
This is an attempt to upgrade to syslog-ng v4.2 (upcoming version).

Test results (based on `ghcr.io/axoflow/syslog-ng:nightly`):
https://github.com/MrAnno/splunk-connect-for-syslog/actions/runs/4838397232/jobs/8622844030

TODO:
- [x] `$(format-json --cast)`
- [x] syslog-ng type-aware comparisons (check all filters)
- [x] `FAILED tests/test_beyondtrust.py::test_beyondtrust_parts - assert 2 == 1` (1 failed, 560 passed))

Depends on:
- syslog-ng/syslog-ng#4415
- syslog-ng/syslog-ng#4394
- syslog-ng/syslog-ng#4401
- syslog-ng/syslog-ng#4390
- syslog-ng/syslog-ng#4410