### PR TITLE
docs: Update CyberArk_PTA vendor product description

### DIFF
--- a/docs/sources/vendor/CyberArk/pta.md
+++ b/docs/sources/vendor/CyberArk/pta.md
@@ -11,6 +11,7 @@
 |----------------|---------------------------------------------------------------------------------------------------------|
 | Splunk Add-on CyberArk | <https://splunkbase.splunk.com/app/2891/>                                                              |
 | Add-on Manual | <https://docs.splunk.com/Documentation/AddOns/latest/CyberArk/About>                                                      |
+| Product Manual | <https://docs.cyberark.com/PAS/Latest/en/Content/PTA/CEF-Based-Format-Definition.htm> |
 
 ## Sourcetypes
 
@@ -22,5 +23,5 @@
 
 | key            | sourcetype     | index          | notes          |
 |----------------|----------------|----------------|----------------|
-| Cyber-Ark_Vault      | cyberark:pta:cef      | main          | none          |
+| CyberArk_PTA      | cyberark:pta:cef      | main          | none          |
 


### PR DESCRIPTION
Incorrect vendor product description in documentation reported: https://github.com/splunk/splunk-connect-for-syslog/issues/2127 .

Key has been updated to match `package/etc/conf.d/conflib/cef/app-cef-cyber_ark_pta.conf` and [vendor documentation](https://docs.cyberark.com/PAS/Latest/en/Content/PTA/CEF-Based-Format-Definition.htm)