### PR TITLE
Fix: fix arista eos miscategorized as cisco ios

### DIFF
--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-cisco_syslog.conf
@@ -57,7 +57,7 @@ block parser app-almost-syslog-cisco_syslog() {
 
 
             )
-            and not match(' [A-Z]\S+$', value('.tmp.header'))
+            and not match('[a-z]\S+$', value('.tmp.header'))
             and not match(' \w+\[\d+\]$', value('.tmp.header'));
 
         };

--- a/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/almost-syslog/app-almost-syslog-cisco_syslog.conf
@@ -57,7 +57,7 @@ block parser app-almost-syslog-cisco_syslog() {
 
 
             )
-            and not match(' [A-Z][a-z][A-Za-z]+$', value('.tmp.header'))
+            and not match(' [A-Z]\S+$', value('.tmp.header'))
             and not match(' \w+\[\d+\]$', value('.tmp.header'));
 
         };

--- a/package/etc/conf.d/conflib/syslog/app-syslog-arista_eos.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-arista_eos.conf
@@ -27,7 +27,7 @@ block parser app-syslog-arista_eos() {
 
 application app-syslog-arista_eos[sc4s-syslog] {
 	filter {
-        program('^[A-Z][A-Za-z]+$')
+        program('^[A-Z]\S+$')
         and message('%' type(string) flags(prefix));
     };	
 

--- a/package/etc/conf.d/conflib/syslog/app-syslog-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-cisco_syslog.conf
@@ -27,7 +27,7 @@ block parser app-syslog-cisco_syslog() {
 };
 application app-syslog-cisco_syslog[sc4s-syslog] {
 	filter {
-        not program('^[A-Z]\S+$')
+        not program('[a-z][^\[\] ]+$')
         and message('(?:: )?%');
     };	
     parser { app-syslog-cisco_syslog(); };

--- a/package/etc/conf.d/conflib/syslog/app-syslog-cisco_syslog.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-cisco_syslog.conf
@@ -27,7 +27,8 @@ block parser app-syslog-cisco_syslog() {
 };
 application app-syslog-cisco_syslog[sc4s-syslog] {
 	filter {
-        message('(?:: )?%');
+        not program('^[A-Z]\S+$')
+        and message('(?:: )?%');
     };	
     parser { app-syslog-cisco_syslog(); };
 };

--- a/tests/test_arista.py
+++ b/tests/test_arista.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-2-clause-style
 # license that can be found in the LICENSE-BSD2 file or at
 # https://opensource.org/licenses/BSD-2-Clause
-import random
+import pytest
 
 from jinja2 import Environment
 
@@ -13,11 +13,15 @@ from .timeutils import *
 
 env = Environment()
 
+test_data = [
+    "{{ mark }} {{ iso }}Z host Acl: %ACL-6-IPACCESS: list acl-internet Ethernet1 denied tcp xxx.xx.xx.xx(63751) -> xxx.xx.xx.xx(445)",
+    "{{ mark }} {{ iso }}Z AleL3Agent-primary: %AGENT-6-INITIALIZED: Agent 'AleL3Agent-primary' initialized; pid=XXXX",
+    "{{ mark }} {{ iso }}Z ProcMgr-worker: %PROCMGR-6-WORKER_WARMSTART: ProcMgr worker warm start. (PID=XXXXX)"
+]
 
-# <111>2021-11-25T16:52:18+01:00 SWITCHNAME.domain.com Acl: %ACL-6-IPACCESS: list acl-internet Ethernet1 denied tcp xxx.xx.xx.xx(63751) -> xxx.xx.xx.xx(445)
-# <111>2021-11-25T16:52:18+01:00 SWITCHNAME.domain.com Acl: 100: %ACL-6-IPACCESS: list acl-internet Ethernet1 denied tcp xxx.xx.xx.xx(63751) -> xxx.xx.xx.xx(445)
-def test_arista_switch(record_property, setup_wordlist, setup_splunk, setup_sc4s):
-    host = "{}-{}".format(random.choice(setup_wordlist), random.choice(setup_wordlist))
+
+@pytest.mark.parametrize("event", test_data)
+def test_arista_switch(record_property, setup_wordlist, setup_splunk, setup_sc4s, event):
 
     #   Get UTC-based 'dt' time structure
     dt = datetime.datetime.now(datetime.timezone.utc)
@@ -28,21 +32,18 @@ def test_arista_switch(record_property, setup_wordlist, setup_splunk, setup_sc4s
     iso = dt.isoformat()[0:19]
     epoch = epoch[:-7]
 
-    mt = env.from_string(
-        "{{ mark }} {{ iso }}Z {{ host }} Acl: %ACL-6-IPACCESS: list acl-internet Ethernet1 denied tcp xxx.xx.xx.xx(63751) -> xxx.xx.xx.xx(445)\n"
-    )
-    message = mt.render(mark="<166>", iso=iso, epoch=epoch, host=host)
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<166>", iso=iso, epoch=epoch)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="arista:eos" source="arista:eos:acl" "ACL-6-IPACCESS"'
+        'search _time={{ epoch }} index=netops sourcetype="arista:eos" source="arista:eos:acl" "ACL-6-IPACCESS"'
     )
-    search = st.render(epoch=epoch, host=host)
+    search = st.render(epoch=epoch)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)
 
-    record_property("host", host)
     record_property("resultCount", resultCount)
     record_property("message", message)
 

--- a/tests/test_cisco_ace.py
+++ b/tests/test_cisco_ace.py
@@ -3,8 +3,6 @@
 # Use of this source code is governed by a BSD-2-clause-style
 # license that can be found in the LICENSE-BSD2 file or at
 # https://opensource.org/licenses/BSD-2-Clause
-import random
-
 from jinja2 import Environment
 
 from .sendmessage import *
@@ -18,8 +16,6 @@ env = Environment()
 def test_cisco_ace_traditional(
     record_property, setup_wordlist, setup_splunk, setup_sc4s
 ):
-    host = "{}-{}".format(random.choice(setup_wordlist), random.choice(setup_wordlist))
-
     dt = datetime.datetime.now()
     iso, bsd, time, date, tzoffset, tzname, epoch = time_operations(dt)
 
@@ -27,20 +23,19 @@ def test_cisco_ace_traditional(
     epoch = epoch[:-7]
 
     mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }}: %ACE-3-251010: Health probe failed for server X.X.X.X on port 8000, server reply timeout\n"
+        "{{ mark }} {{ bsd }} 192.168.12.1: %ACE-3-251010: Health probe failed for server X.X.X.X on port 8000, server reply timeout\n"
     )
-    message = mt.render(mark="<111>", bsd=bsd, host=host)
+    message = mt.render(mark="<111>", bsd=bsd)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="cisco:ace"'
+        'search _time={{ epoch }} index=netops sourcetype="cisco:ace"'
     )
-    search = st.render(epoch=epoch, host=host)
+    search = st.render(epoch=epoch)
 
     resultCount, eventCount = splunk_single(setup_splunk, search)
 
-    record_property("host", host)
     record_property("resultCount", resultCount)
     record_property("message", message)
 


### PR DESCRIPTION
In https://github.com/splunk/splunk-connect-for-syslog/issues/2139 it has been reported that some Arista EOS logs are miscategorized as Cisco IOS.

In fact those two vendors use a very similar log format. 
The difference is **Arista** will always contain program name before the first colon:
`Aug 18 03:36:42 AleL3Agent-primary: %AGENT-6-INITIALIZED: Agent 'AleL3Agent-primary' initialized; pid=XXXX`

In **Cisco** there is usually just a timestamp:
`Feb 14 09:40:10.326: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up`

Sometimes timestamp with timezone:
`{{ mark }}: {{ year }} {{ bsd }} PDT: %DAEMON-3-SYSTEM_MSG: ftp disabled, removing - xinetd[4930] {{ host }}`

And sometimes also program name, but with all letters uppercase:
`'{{ mark }}{{ bsd }} SYSMGR[919]: %Viptela-{{ host }}-sysmgrd-6-INFO-1400002: Notification: 3/17/2022 18:35:12 system-login-change severity-level:minor host-name:"{{ host }}" system-ip:1.1.1.3 user-name:"mn2c" user-id:2227\n'`

This PR adds new test cases based on the customer issue, as well as updates Cisco and Arista parsers to properly catch the differences