### PR TITLE
Fixed match for Sophos XG Firewall that has device_name=SFW instead o…

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-sophos_firewall_xg.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-sophos_firewall_xg.conf
@@ -121,7 +121,8 @@ block parser app-syslog-sophos_firewall_xg() {
 application app-syslog-sophos_firewall_xg[sc4s-syslog] {
     filter {
         (
-            message("device=\"SFW\"" type(string) flags(substring)) and
+            message("device=\"SFW\"" type(string) flags(substring)) or
+            message("device_name=\"SFW\"" type(string) flags(substring)) and
             message("log_type=" type(string) flags(substring))
         );
     };


### PR DESCRIPTION
…f device=SFW