### PR TITLE
Fix conditional/code path for vendor_product_by_source parsing

### DIFF
--- a/package/etc/conf.d/sources/source_syslog/plugin.jinja
+++ b/package/etc/conf.d/sources/source_syslog/plugin.jinja
@@ -219,12 +219,13 @@ source s_{{ port_id }} {
             rewrite {
                 set('$(lowercase "$HOST")' value(HOST));
             };
-            {%- if not vendor or not product %}
-            {%- if use_vpscache == True %}
+            {%- if ( (not vendor or not product) and
+                     (use_vpscache == True) ) %}
             if {
                 parser(p_vpst_cache);
             };
             {%- endif %}
+            {%- if vendor and product %}
             if {
                 parser(vendor_product_by_source);
             };
@@ -426,12 +427,13 @@ source s_{{ port_id }} {
         rewrite {
             set('$(lowercase "$HOST")' value(HOST));
         };
-        {%- if not vendor or not product %}
-        {%- if use_vpscache == True %}
+        {%- if ( (not vendor or not product) and
+               (use_vpscache == True) ) %}
         if {
             parser(p_vpst_cache);
         };
         {%- endif %}
+        {%- if vendor and product %}
         if {
             parser(vendor_product_by_source);
         };


### PR DESCRIPTION
See https://github.com/splunk/splunk-connect-for-syslog/issues/2415 for discussion.

Proposed change to conditional logic which calls parser(vendor_product_by_source) as it's currently getting bypassed.