### PR TITLE
Fix for the issue 2475: 

### DIFF
--- a/ansible/resources/docker_sc4s.service
+++ b/ansible/resources/docker_sc4s.service
@@ -30,6 +30,8 @@ ExecStartPre=/usr/bin/docker pull $SC4S_IMAGE
 # when startup fails on running bash check if the path is correct
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
 
+# Note: Prevent the error "Can't create container because exists another container with SC4S name"
+ExecStartPre=sh -c 'docker container rm SC4S || /bin/true'
 ExecStart=/usr/bin/docker run \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         -v "$SC4S_PERSIST_MOUNT" \

--- a/ansible/resources/podman_sc4s.service
+++ b/ansible/resources/podman_sc4s.service
@@ -29,6 +29,8 @@ ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 # when startup fails on running bash check if the path is correct
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
 
+# Note: Prevent the error "Can't create container because exists another container with SC4S name"
+ExecStartPre=sh -c 'podman container rm SC4S || /bin/true'
 ExecStart=/usr/bin/podman run \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         -v "$SC4S_PERSIST_MOUNT" \

--- a/docs/resources/docker/sc4s.service
+++ b/docs/resources/docker/sc4s.service
@@ -30,6 +30,8 @@ ExecStartPre=/usr/bin/docker pull $SC4S_IMAGE
 # when startup fails on running bash check if the path is correct
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
 
+# Note: Prevent the error "Can't create container because exists another container with SC4S name"
+ExecStartPre=sh -c 'docker container rm SC4S || /bin/true'
 ExecStart=/usr/bin/docker run \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         -v "$SC4S_PERSIST_MOUNT" \

--- a/docs/resources/podman/sc4s.service
+++ b/docs/resources/podman/sc4s.service
@@ -29,6 +29,8 @@ ExecStartPre=/usr/bin/podman pull $SC4S_IMAGE
 # when startup fails on running bash check if the path is correct
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment SC4SHOST=$(hostname -s)"
 
+# Note: Prevent the error "Can't create container because exists another container with SC4S name"
+ExecStartPre=sh -c 'podman container rm SC4S || /bin/true'
 ExecStart=/usr/bin/podman run \
         -e "SC4S_CONTAINER_HOST=${SC4SHOST}" \
         -v "$SC4S_PERSIST_MOUNT" \


### PR DESCRIPTION
When a VM or Computer with SC4S shutdown suddently because electrical outage or other problems, SC4S container is not removed, so when you try to start again an error is fired with "Can not create, another container with SC4S name exists!"

Executing this ExecStartPre ensures that if the container exists is deleted. If the container doesn't exist the code || /bin/true makes the script continue.

Issue link: https://github.com/splunk/splunk-connect-for-syslog/issues/2475

@ikheifets-splunk is checking the issue