### PR TITLE
feat: Support for Cisco ESA 15.5.1 log out events

### DIFF
--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -38,7 +38,7 @@ filter f_cisco_esa_authentication {
     or match('failed\s*authentication.', value("MESSAGE"))
     or match('Time\s*offset\s*from\s*UTC:', value("MESSAGE"))
     or match('[vV]ersion:\s+.*\s+SN:\s+.*', value("MESSAGE"))
-    or match('\s*(?:login|logout):\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\s*login|logout:\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
     or match('\slogged\s*out\s*', value("MESSAGE"))
     or match('MAR_SecurityAudit', value("MESSAGE"))
 };

--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -38,7 +38,8 @@ filter f_cisco_esa_authentication {
     or match('failed\s*authentication.', value("MESSAGE"))
     or match('Time\s*offset\s*from\s*UTC:', value("MESSAGE"))
     or match('[vV]ersion:\s+.*\s+SN:\s+.*', value("MESSAGE"))
-    or match('\s*login|logout:\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\s*(?:login|logout):\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\slogged\s*out\s*', value("MESSAGE"))
     or match('MAR_SecurityAudit', value("MESSAGE"))
 };
 

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -38,7 +38,7 @@ filter f_cisco_esa_authentication {
     or match('failed\s*authentication.', value("MESSAGE"))
     or match('Time\s*offset\s*from\s*UTC:', value("MESSAGE"))
     or match('[vV]ersion:\s+.*\s+SN:\s+.*', value("MESSAGE"))
-    or match('\s*(?:login|logout):\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\s*login|logout:\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
     or match('\slogged\s*out\s*', value("MESSAGE"))
     or match('MAR_SecurityAudit', value("MESSAGE"))
 };

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -38,7 +38,8 @@ filter f_cisco_esa_authentication {
     or match('failed\s*authentication.', value("MESSAGE"))
     or match('Time\s*offset\s*from\s*UTC:', value("MESSAGE"))
     or match('[vV]ersion:\s+.*\s+SN:\s+.*', value("MESSAGE"))
-    or match('\s*login|logout:\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\s*(?:login|logout):\s*[^\s]*\s*[Uu]ser:[\w\-]+\s*session:[^\s]+', value("MESSAGE"))
+    or match('\slogged\s*out\s*', value("MESSAGE"))
     or match('MAR_SecurityAudit', value("MESSAGE"))
 };
 

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -50,6 +50,7 @@ testdata_authentication = [
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:11 2020 Info: Time offset from UTC: 19207 seconds",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:43:53 2020 Info: User dummy_user2 from 184.186.3.161 failed authentication.",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:37:45 2020 Info: Version: 8.7.2-004 SN: 1024E857D276-JXKWBK2",
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:51 2020 Info: login:2.85.228.227 user:dummy_user2 session:LH09MofqDf2j21zW9QN5",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:51 2020 Info: logout:64.205.160.240 user:dummy_user1 session:LH09MofqDf2j21zW9QN1",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:51 2020 Info: PID 2585: User admin logged out from session because of inactivity timeout.",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Aug  3 07:26:33  10.0.1.1 MAR_SecurityAudit: Info: Message containing attachment(s) for which verdict update was(were) available was not found in the recipient's (<EMAIL>) mailbox.",

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -51,6 +51,7 @@ testdata_authentication = [
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:43:53 2020 Info: User dummy_user2 from 184.186.3.161 failed authentication.",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:37:45 2020 Info: Version: 8.7.2-004 SN: 1024E857D276-JXKWBK2",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:51 2020 Info: logout:64.205.160.240 user:dummy_user1 session:LH09MofqDf2j21zW9QN1",
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Mon Aug 10 09:44:51 2020 Info: PID 2585: User admin logged out from session because of inactivity timeout.",
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Aug  3 07:26:33  10.0.1.1 MAR_SecurityAudit: Info: Message containing attachment(s) for which verdict update was(were) available was not found in the recipient's (<EMAIL>) mailbox.",
 ]
 


### PR DESCRIPTION
Jira Ticket: https://splunk.atlassian.net/browse/ADDON-71783
Added support for new log-out events(ESA 15.5.1-onprem).

`<14>Jun 4 15:45:37 ironport.esa.com Info: PID 2585: User admin logged out from session because of inactivity timeout.`