### PR TITLE
feat: add support for new sourcetypes of Cisco ESA TA v1.7.0

### DIFF
--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -48,6 +48,41 @@ filter f_cisco_esa_antispam {
     or program('sc4s_antispam' type(string) flags(prefix))
 };
 
+filter f_cisco_esa_antivirus {
+    program('antivirus' type(string) flags(prefix))
+    or program('sc4s_antivirus' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_euq_logs {
+    program('euq_logs' type(string) flags(prefix))
+    or program('sc4s_euq_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_service_logs {
+    program('service_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_reportd_logs {
+    program('reportd_logs' type(string) flags(prefix))
+    or program('sc4s_reportd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_sntpd_logs {
+    program('sntpd_logs' type(string) flags(prefix))
+    or program('sc4s_sntpd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_smartlicense {
+    program('smartlicense' type(string) flags(prefix))
+    or program('sc4s_smartlicense' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_updater_logs {
+    program('updater_logs' type(string) flags(prefix))
+    or program('sc4s_updater_logs' type(string) flags(prefix))
+};
+
 filter f_cisco_esa_content_scanner {
     program('content_scanner' type(string) flags(prefix))
     or program('sc4s_content_scanner' type(string) flags(prefix))
@@ -61,41 +96,6 @@ filter f_cisco_esa_error_logs {
 filter f_cisco_esa_system_logs {
     program('system_logs' type(string) flags(prefix))
     or program('sc4s_system_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_updater_logs {
-    program('updater_logs' type(string) flags(prefix))
-    or program('sc4s_updater_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_antivirus_logs {
-    program('antivirus' type(string) flags(prefix))
-    or program('sc4s_antivirus' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_service_logs {
-    program('service_logs' type(string) flags(prefix))
-    or program('sc4s_service_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_reportd_logs {
-    program('reportd_logs' type(string) flags(prefix))
-    or program('sc4s_service_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_sntpd_logs {
-    program('sntpd_logs' type(string) flags(prefix))
-    or program('sc4s_sntpd_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_euq_logs {
-    program('euq_logs' type(string) flags(prefix))
-    or program('sc4s_euq_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_smartlicense {
-    program('smartlicense' type(string) flags(prefix))
-    or program('sc4s_smartlicense' type(string) flags(prefix))
 };
 
 
@@ -128,6 +128,62 @@ block parser app-netsource-cisco_esa() {
                 r_set_splunk_dest_update_v2(
                      source('esa:http')
                      sourcetype('cisco:esa:http')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:antivirus')
+                     sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:euq_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:service_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:reportd_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_sntpd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:sntpd_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_smartlicense);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:smartlicense')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_updater_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:updater_logs')
+                     sourcetype('cisco:esa:error_logs')
                 );
             };
         } elif {
@@ -167,94 +223,6 @@ block parser app-netsource-cisco_esa() {
             rewrite {
                 r_set_splunk_dest_update_v2(
                     source('esa:system_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_updater_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:updater_logs')
-                    sourcetype('cisco:esa:error_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:antivirus')
-                    sourcetype('cisco:esa:antivirus')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_euq_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:euq_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_service_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:service_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_reportd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:reportd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:antivirus')
-                    sourcetype('cisco:esa:antivirus')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_euq_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:euq_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_service_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:service_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_reportd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:reportd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_sntpd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:sntpd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_smartlicense);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:smartlicense')
                     sourcetype('cisco:esa:system_logs')
                 );
             };

--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -58,6 +58,11 @@ filter f_cisco_esa_error_logs {
     or program('sc4s_error_logs' type(string) flags(prefix))
 };
 
+filter f_cisco_esa_system_logs {
+    program('system_logs' type(string) flags(prefix))
+    or program('sc4s_system_logs' type(string) flags(prefix))
+};
+
 filter f_cisco_esa_updater_logs {
     program('updater_logs' type(string) flags(prefix))
     or program('sc4s_updater_logs' type(string) flags(prefix))

--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -48,11 +48,6 @@ filter f_cisco_esa_antispam {
     or program('sc4s_antispam' type(string) flags(prefix))
 };
 
-filter f_cisco_esa_antivirus {
-    program('antivirus' type(string) flags(prefix))
-    or program('sc4s_antivirus' type(string) flags(prefix))
-};
-
 filter f_cisco_esa_euq_logs {
     program('euq_logs' type(string) flags(prefix))
     or program('sc4s_euq_logs' type(string) flags(prefix))
@@ -128,14 +123,6 @@ block parser app-netsource-cisco_esa() {
                 r_set_splunk_dest_update_v2(
                      source('esa:http')
                      sourcetype('cisco:esa:http')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                     source('esa:antivirus')
-                     sourcetype('cisco:esa:antivirus')
                 );
             };
         } elif {

--- a/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
+++ b/package/etc/conf.d/conflib/netsource/app-netsource-cisco_esa.conf
@@ -58,9 +58,39 @@ filter f_cisco_esa_error_logs {
     or program('sc4s_error_logs' type(string) flags(prefix))
 };
 
-filter f_cisco_esa_system_logs {
-    program('system_logs' type(string) flags(prefix))
-    or program('sc4s_system_logs' type(string) flags(prefix))
+filter f_cisco_esa_updater_logs {
+    program('updater_logs' type(string) flags(prefix))
+    or program('sc4s_updater_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_antivirus_logs {
+    program('antivirus' type(string) flags(prefix))
+    or program('sc4s_antivirus' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_service_logs {
+    program('service_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_reportd_logs {
+    program('reportd_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_sntpd_logs {
+    program('sntpd_logs' type(string) flags(prefix))
+    or program('sc4s_sntpd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_euq_logs {
+    program('euq_logs' type(string) flags(prefix))
+    or program('sc4s_euq_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_smartlicense {
+    program('smartlicense' type(string) flags(prefix))
+    or program('sc4s_smartlicense' type(string) flags(prefix))
 };
 
 
@@ -132,6 +162,94 @@ block parser app-netsource-cisco_esa() {
             rewrite {
                 r_set_splunk_dest_update_v2(
                     source('esa:system_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_updater_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:updater_logs')
+                    sourcetype('cisco:esa:error_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:antivirus')
+                    sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:euq_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:service_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:reportd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:antivirus')
+                    sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:euq_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:service_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:reportd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_sntpd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:sntpd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_smartlicense);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:smartlicense')
                     sourcetype('cisco:esa:system_logs')
                 );
             };

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -48,6 +48,41 @@ filter f_cisco_esa_antispam {
     or program('sc4s_antispam' type(string) flags(prefix))
 };
 
+filter f_cisco_esa_antivirus {
+    program('antivirus' type(string) flags(prefix))
+    or program('sc4s_antivirus' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_euq_logs {
+    program('euq_logs' type(string) flags(prefix))
+    or program('sc4s_euq_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_service_logs {
+    program('service_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_reportd_logs {
+    program('reportd_logs' type(string) flags(prefix))
+    or program('sc4s_reportd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_sntpd_logs {
+    program('sntpd_logs' type(string) flags(prefix))
+    or program('sc4s_sntpd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_smartlicense {
+    program('smartlicense' type(string) flags(prefix))
+    or program('sc4s_smartlicense' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_updater_logs {
+    program('updater_logs' type(string) flags(prefix))
+    or program('sc4s_updater_logs' type(string) flags(prefix))
+};
+
 filter f_cisco_esa_content_scanner {
     program('content_scanner' type(string) flags(prefix))
     or program('sc4s_content_scanner' type(string) flags(prefix))
@@ -61,41 +96,6 @@ filter f_cisco_esa_error_logs {
 filter f_cisco_esa_system_logs {
     program('system_logs' type(string) flags(prefix))
     or program('sc4s_system_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_updater_logs {
-    program('updater_logs' type(string) flags(prefix))
-    or program('sc4s_updater_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_antivirus_logs {
-    program('antivirus' type(string) flags(prefix))
-    or program('sc4s_antivirus' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_service_logs {
-    program('service_logs' type(string) flags(prefix))
-    or program('sc4s_service_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_reportd_logs {
-    program('reportd_logs' type(string) flags(prefix))
-    or program('sc4s_service_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_sntpd_logs {
-    program('sntpd_logs' type(string) flags(prefix))
-    or program('sc4s_sntpd_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_euq_logs {
-    program('euq_logs' type(string) flags(prefix))
-    or program('sc4s_euq_logs' type(string) flags(prefix))
-};
-
-filter f_cisco_esa_smartlicense {
-    program('smartlicense' type(string) flags(prefix))
-    or program('sc4s_smartlicense' type(string) flags(prefix))
 };
 
 
@@ -128,6 +128,62 @@ block parser app-netsource-cisco_esa() {
                 r_set_splunk_dest_update_v2(
                      source('esa:http')
                      sourcetype('cisco:esa:http')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:antivirus')
+                     sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:euq_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:service_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:reportd_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_sntpd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:sntpd_logs')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_smartlicense);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:smartlicense')
+                     sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_updater_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                     source('esa:updater_logs')
+                     sourcetype('cisco:esa:error_logs')
                 );
             };
         } elif {
@@ -167,94 +223,6 @@ block parser app-netsource-cisco_esa() {
             rewrite {
                 r_set_splunk_dest_update_v2(
                     source('esa:system_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_updater_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:updater_logs')
-                    sourcetype('cisco:esa:error_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:antivirus')
-                    sourcetype('cisco:esa:antivirus')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_euq_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:euq_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_service_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:service_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_reportd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:reportd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:antivirus')
-                    sourcetype('cisco:esa:antivirus')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_euq_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:euq_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_service_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:service_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_reportd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:reportd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_sntpd_logs);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:sntpd_logs')
-                    sourcetype('cisco:esa:system_logs')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_smartlicense);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                    source('esa:smartlicense')
                     sourcetype('cisco:esa:system_logs')
                 );
             };

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -58,6 +58,11 @@ filter f_cisco_esa_error_logs {
     or program('sc4s_error_logs' type(string) flags(prefix))
 };
 
+filter f_cisco_esa_system_logs {
+    program('system_logs' type(string) flags(prefix))
+    or program('sc4s_system_logs' type(string) flags(prefix))
+};
+
 filter f_cisco_esa_updater_logs {
     program('updater_logs' type(string) flags(prefix))
     or program('sc4s_updater_logs' type(string) flags(prefix))

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -48,11 +48,6 @@ filter f_cisco_esa_antispam {
     or program('sc4s_antispam' type(string) flags(prefix))
 };
 
-filter f_cisco_esa_antivirus {
-    program('antivirus' type(string) flags(prefix))
-    or program('sc4s_antivirus' type(string) flags(prefix))
-};
-
 filter f_cisco_esa_euq_logs {
     program('euq_logs' type(string) flags(prefix))
     or program('sc4s_euq_logs' type(string) flags(prefix))
@@ -128,14 +123,6 @@ block parser app-netsource-cisco_esa() {
                 r_set_splunk_dest_update_v2(
                      source('esa:http')
                      sourcetype('cisco:esa:http')
-                );
-            };
-        } elif {
-            filter(f_cisco_esa_antivirus);
-            rewrite {
-                r_set_splunk_dest_update_v2(
-                     source('esa:antivirus')
-                     sourcetype('cisco:esa:antivirus')
                 );
             };
         } elif {

--- a/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
+++ b/package/lite/etc/addons/cisco/app-netsource-cisco_esa.conf
@@ -58,9 +58,39 @@ filter f_cisco_esa_error_logs {
     or program('sc4s_error_logs' type(string) flags(prefix))
 };
 
-filter f_cisco_esa_system_logs {
-    program('system_logs' type(string) flags(prefix))
-    or program('sc4s_system_logs' type(string) flags(prefix))
+filter f_cisco_esa_updater_logs {
+    program('updater_logs' type(string) flags(prefix))
+    or program('sc4s_updater_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_antivirus_logs {
+    program('antivirus' type(string) flags(prefix))
+    or program('sc4s_antivirus' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_service_logs {
+    program('service_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_reportd_logs {
+    program('reportd_logs' type(string) flags(prefix))
+    or program('sc4s_service_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_sntpd_logs {
+    program('sntpd_logs' type(string) flags(prefix))
+    or program('sc4s_sntpd_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_euq_logs {
+    program('euq_logs' type(string) flags(prefix))
+    or program('sc4s_euq_logs' type(string) flags(prefix))
+};
+
+filter f_cisco_esa_smartlicense {
+    program('smartlicense' type(string) flags(prefix))
+    or program('sc4s_smartlicense' type(string) flags(prefix))
 };
 
 
@@ -132,6 +162,94 @@ block parser app-netsource-cisco_esa() {
             rewrite {
                 r_set_splunk_dest_update_v2(
                     source('esa:system_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_updater_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:updater_logs')
+                    sourcetype('cisco:esa:error_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:antivirus')
+                    sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:euq_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:service_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:reportd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_antivirus);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:antivirus')
+                    sourcetype('cisco:esa:antivirus')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_euq_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:euq_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_service_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:service_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_reportd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:reportd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_sntpd_logs);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:sntpd_logs')
+                    sourcetype('cisco:esa:system_logs')
+                );
+            };
+        } elif {
+            filter(f_cisco_esa_smartlicense);
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    source('esa:smartlicense')
                     sourcetype('cisco:esa:system_logs')
                 );
             };

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -93,21 +93,6 @@ testdata_system_logs = [
     "{{mark}} {{ bsd }} {{ app }}: Info: lame DNS referral: qname:173-212-12-198.cpe.surry.net ns_name:dns1.surry.net zone:cpe.surry.net ref_zone:cpe.surry.net referrals:[(524666183436709L, 0, 'insecure', 'dns1.surry.net'), (524666183436709L, 0, 'insecure', 'dns2.surry.net')]",
 ]
 
-testdata_antivirus = [
-    """{{mark}} {{ bsd }} {{ host }} {{ app }}: Warning: sophos antivirus - The Anti-Virus database on this system is expired. Although the system
-will continue to scan for existing viruses, new virus updates will no
-longer be available. Please run avupdate to update to the latest engine
-immediately. Contact Cisco IronPort Customer Support if you have any
-questions.
-
-Current Sophos Anti-Virus Information:
-
-SAV Engine Version 5.88
-IDE Serial Unknown
-Last Engine Update Sat Apr 13 15:35:20 2024
-Last IDE Update Sat Apr 13 15:35:20 2024
-""" ]
-
 testdata_euq_logs =[
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: ISQ: out of limit action changed to 'DELETE OLDEST'"
 ]
@@ -279,37 +264,6 @@ def test_cisco_esa_error_logs(
 
     st = env.from_string(
         'search index=email _time={{ epoch }} sourcetype="cisco:esa:error_logs" _raw="{{ message }}"'
-    )
-    message1 = mt.render(mark="", bsd="", app="")
-    message1 = message1.lstrip()
-    search = st.render(epoch=epoch, message=message1[2:])
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-@pytest.mark.parametrize("event", testdata_antivirus)
-@pytest.mark.addons("cisco")
-def test_cisco_esa_antivirus(
-    record_property,  setup_splunk, setup_sc4s, event
-):
-
-    dt = datetime.datetime.now()
-    _, bsd, _, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    epoch = epoch[:-7]
-
-    mt = env.from_string(event + "\n")
-    message = mt.render(mark="<111>", bsd=bsd, app="antivirus",host="cisco_esa")
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search index=email _time={{ epoch }} sourcetype="cisco:esa:antivirus" source=esa:antivirus _raw="{{ message }}"'
     )
     message1 = mt.render(mark="", bsd="", app="")
     message1 = message1.lstrip()

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -93,6 +93,44 @@ testdata_system_logs = [
     "{{mark}} {{ bsd }} {{ app }}: Info: lame DNS referral: qname:173-212-12-198.cpe.surry.net ns_name:dns1.surry.net zone:cpe.surry.net ref_zone:cpe.surry.net referrals:[(524666183436709L, 0, 'insecure', 'dns1.surry.net'), (524666183436709L, 0, 'insecure', 'dns2.surry.net')]",
 ]
 
+testdata_antivirus = [
+    """{{mark}} {{ bsd }} {{ host }} {{ app }}: Warning: sophos antivirus - The Anti-Virus database on this system is expired. Although the system
+will continue to scan for existing viruses, new virus updates will no
+longer be available. Please run avupdate to update to the latest engine
+immediately. Contact Cisco IronPort Customer Support if you have any
+questions.
+
+Current Sophos Anti-Virus Information:
+
+SAV Engine Version 5.88
+IDE Serial Unknown
+Last Engine Update Sat Apr 13 15:35:20 2024
+Last IDE Update Sat Apr 13 15:35:20 2024
+""" ]
+
+testdata_euq_logs =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: ISQ: out of limit action changed to 'DELETE OLDEST'"
+]
+
+testdata_service_logs =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: service_log_client.telemetry_rpc_server : THR: Thread-152: ESA messages results sent for the MID: 107."
+]
+
+testdata_reportd_logs =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: TLS connection failed because of an unsupported protocol issue. Alert message is sent in plain text to user1@esa.com"
+]
+
+testdata_sntpd_logs =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: The system time was changed from Sun, 16 Jun 2024 21:00:52 to Sun, 16 Jun 2024 21:00:53 using information from 207.54.66.52."
+]
+
+testdata_smartlicense =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: Hostname is successfully changed to cisco_esa for the product."
+]
+
+testdata_updater_logs =[
+    "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: case waiting for new updates"
+]
 
 @pytest.mark.parametrize("event", testdata_gui_logs)
 @pytest.mark.addons("cisco")
@@ -253,6 +291,222 @@ def test_cisco_esa_error_logs(
 
     assert result_count == 1
 
+@pytest.mark.parametrize("event", testdata_antivirus)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_antivirus(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="antivirus",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:antivirus" source=esa:antivirus _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_euq_logs)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_euq_logs(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="euq_logs",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:system_logs" source=esa:euq_logs _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_service_logs)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_service_logs(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="service_logs",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:system_logs" source=esa:service_logs _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_reportd_logs)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_reportd_logs(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="reportd_logs",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:system_logs" source=esa:reportd_logs _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_sntpd_logs)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_sntpd_logs(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="sntpd_logs",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:system_logs" source=esa:sntpd_logs _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_smartlicense)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_smartlicense(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="smartlicense",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:system_logs" source=esa:smartlicense _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_updater_logs)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_updater_logs(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="updater_logs",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][9000])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:error_logs" source=esa:updater_logs _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
 
 @pytest.mark.parametrize("event", testdata_antispam)
 @pytest.mark.addons("cisco")

--- a/tests/test_cisco_esa.py
+++ b/tests/test_cisco_esa.py
@@ -93,6 +93,21 @@ testdata_system_logs = [
     "{{mark}} {{ bsd }} {{ app }}: Info: lame DNS referral: qname:173-212-12-198.cpe.surry.net ns_name:dns1.surry.net zone:cpe.surry.net ref_zone:cpe.surry.net referrals:[(524666183436709L, 0, 'insecure', 'dns1.surry.net'), (524666183436709L, 0, 'insecure', 'dns2.surry.net')]",
 ]
 
+testdata_antivirus = [
+    """{{mark}} {{ bsd }} {{ host }} {{ app }}: Warning: sophos antivirus - The Anti-Virus database on this system is expired. Although the system
+will continue to scan for existing viruses, new virus updates will no
+longer be available. Please run avupdate to update to the latest engine
+immediately. Contact Cisco IronPort Customer Support if you have any
+questions.
+
+Current Sophos Anti-Virus Information:
+
+SAV Engine Version 5.88
+IDE Serial Unknown
+Last Engine Update Sat Apr 13 15:35:20 2024
+Last IDE Update Sat Apr 13 15:35:20 2024
+""" ]
+
 testdata_euq_logs =[
     "{{mark}} {{ bsd }} {{ host }} {{ app }}: Info: ISQ: out of limit action changed to 'DELETE OLDEST'"
 ]
@@ -264,6 +279,37 @@ def test_cisco_esa_error_logs(
 
     st = env.from_string(
         'search index=email _time={{ epoch }} sourcetype="cisco:esa:error_logs" _raw="{{ message }}"'
+    )
+    message1 = mt.render(mark="", bsd="", app="")
+    message1 = message1.lstrip()
+    search = st.render(epoch=epoch, message=message1[2:])
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+@pytest.mark.parametrize("event", testdata_antivirus)
+@pytest.mark.addons("cisco")
+def test_cisco_esa_antivirus(
+    record_property,  setup_splunk, setup_sc4s, event
+):
+
+    dt = datetime.datetime.now()
+    _, bsd, _, _, _, _, epoch = time_operations(dt)
+
+    # Tune time functions
+    epoch = epoch[:-7]
+
+    mt = env.from_string(event + "\n")
+    message = mt.render(mark="<111>", bsd=bsd, app="antivirus",host="cisco_esa")
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search index=email _time={{ epoch }} sourcetype="cisco:esa:antivirus" source=esa:antivirus _raw="{{ message }}"'
     )
     message1 = mt.render(mark="", bsd="", app="")
     message1 = message1.lstrip()


### PR DESCRIPTION
Jira_ticket: https://splunk.atlassian.net/browse/ADDON-72562
Added new sourcetype

- cisco:esa:antivirus

Also mapped the following programs into **cisco:esa:system_logs**

- euq_logs
- service_logs
- reportd_logs
- sntpd_logs
- smartlicense

Additionally mapped the updater_logs into **cisco:esa:error_logs**
