### PR TITLE
feat: Adds config checksums to Helm chart to trigger rollout on change

### DIFF
--- a/charts/splunk-connect-for-syslog/templates/statefulset.yaml
+++ b/charts/splunk-connect-for-syslog/templates/statefulset.yaml
@@ -15,8 +15,17 @@ spec:
       {{- include "splunk-connect-for-syslog.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- if .Values.sc4s.config_files }}
+        checksum/config: {{ include (print $.Template.BasePath "/config-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.sc4s.addons }}
+        checksum/addon-config: {{ include (print $.Template.BasePath "/addon-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.sc4s.context_files }}
+        checksum/context-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
We're running into issues where, after updating our config in the chart, we then need to manually restart the StatefulSet in order for it to get the changes. This PR adds checksum annotations for all three ConfigMaps to the StatefulSet, such that changing the config in any way will automatically trigger a rollout.