### PR TITLE
add filter for junos perfmon events

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-juniper_junos_unstructured.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-juniper_junos_unstructured.conf
@@ -57,6 +57,14 @@ block parser app-syslog-juniper_junos_unstructured() {
                         sourcetype('juniper:junos:snmp')
                 );
             };
+        } elif (program('PERF_MON' type(string) flags(prefix)) and message('RTPERF_')) {
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                        index('netops')
+                        class('perfmon')
+                        sourcetype('juniper:junos:perfmon')
+                );
+            };
         }
         else {
             rewrite {
@@ -81,6 +89,7 @@ application app-syslog-juniper_junos_unstructured-pgm[sc4s-syslog-pgm] {
         or program('ESWD_' type(string) flags(prefix))
         or program('mgd' type(string))
         or program('mcsnoopd' type(string))
+        or (program('PERF_MON' type(string)) and message('RTPERF_'))
         or (program('ifinfo' type(string)) and message('^PVIDB'))
         ;
     };	


### PR DESCRIPTION
create filter to capture junos events.

examples

> PERF_MON: RTPERF_CPU_UTIL_MAX: FPC 0 PIC 0 CPU Utilization greater than 99, expect packet loss

> PERF_MON: RTPERF_CPU_THRESHOLD_EXCEEDED: FPC 0 PIC 0 CPU utilization exceeds threshold, current value = 99