### PR TITLE
feat: load host IP from proxied source IP

### DIFF
--- a/package/etc/conf.d/conflib/_splunk/splunkfields.conf
+++ b/package/etc/conf.d/conflib/_splunk/splunkfields.conf
@@ -128,3 +128,8 @@ filter f_is_source_identified{
 filter f_is_agg{
     tags("agg");
 };
+
+filter f_is_proxy_ip{
+    "$HOST" eq "$SOURCEIP"
+    and "$PROXIED_SRCIP" ne ""
+};

--- a/package/etc/conf.d/sources/internal.conf
+++ b/package/etc/conf.d/sources/internal.conf
@@ -114,6 +114,7 @@ source s_internal {
                     or match("Syslog connection closed; fd=" value("MESSAGE"))
                     or match("Syslog connection accepted; fd=" value("MESSAGE"))
                     or match("xml-parser failed; " value("MESSAGE"))
+                    or match("Initializing PROXY protocol source driver" value("MESSAGE"))
                 };
                 rewrite(r_set_dest_splunk_null_queue);
             };           

--- a/package/etc/conf.d/sources/source_syslog/plugin.jinja
+++ b/package/etc/conf.d/sources/source_syslog/plugin.jinja
@@ -114,6 +114,13 @@ source s_{{ port_id }} {
             );
         };
         {%- endif %}
+
+        {%- if use_proxy_connect == True %}
+            rewrite {
+                set("$PROXIED_SRCIP", value("HOST") condition("$PROXIED_SRCIP" ne ""));
+            };
+        {%- endif %}
+
         if {
             if {
                 parser {
@@ -391,6 +398,13 @@ source s_{{ port_id }} {
             {%- endif %}
             {%- endfor %}
         };
+
+        {%- if use_proxy_connect == True %}
+            rewrite {
+                set("$PROXIED_SRCIP", value("HOST") condition("$PROXIED_SRCIP" ne ""));
+            };
+        {%- endif %}
+
         {%- if vendor and product %}
         parser {
             p_set_netsource_fields(

--- a/package/etc/conf.d/sources/source_syslog/plugin.jinja
+++ b/package/etc/conf.d/sources/source_syslog/plugin.jinja
@@ -117,7 +117,7 @@ source s_{{ port_id }} {
 
         {%- if use_proxy_connect == True %}
             rewrite {
-                set("$PROXIED_SRCIP", value("HOST") condition("$PROXIED_SRCIP" ne ""));
+                set("$PROXIED_SRCIP", value("HOST") condition(filter(f_is_proxy_ip)) );
             };
         {%- endif %}
 
@@ -401,7 +401,7 @@ source s_{{ port_id }} {
 
         {%- if use_proxy_connect == True %}
             rewrite {
-                set("$PROXIED_SRCIP", value("HOST") condition("$PROXIED_SRCIP" ne ""));
+                set("$PROXIED_SRCIP", value("HOST") condition(filter(f_is_proxy_ip)) );
             };
         {%- endif %}
 


### PR DESCRIPTION
SC4S already supports the proxy protocol which is useful in some scenarios when using proxies or LBs: https://www.syslog-ng.com/community/b/blog/posts/finding-the-real-source-ip-using-the-proxy-protocol-with-syslog-ng

This PR implements a new overwrite. If `SC4S_SOURCE_PROXYCONNECT=yes`, SC4S will overwrite the HOST value with `PROXIED_SRCIP`.

Before the change:
`host` set to the LB IP
![image](https://github.com/user-attachments/assets/33252081-b58b-4857-ba12-de7c746ebb46)

After:
`host` set to the IP of the source
![image](https://github.com/user-attachments/assets/41bb7c0f-0dd0-4d14-863b-374be039d9da)
