### PR TITLE
docs: Updating the vendor documentation with the correct port number (5425)…

### DIFF
--- a/docs/sources/vendor/PaloaltoNetworks/cortexxdr.md
+++ b/docs/sources/vendor/PaloaltoNetworks/cortexxdr.md
@@ -3,7 +3,7 @@
 ## Key facts
 
 * MSG Format based filter
-* Cortex requires TLS and uses IETF Framed SYSLOG default port is 6587
+* Cortex requires TLS and uses IETF Framed SYSLOG default port is 5425
 
 | Ref            | Link                                                                                                    |
 |----------------|---------------------------------------------------------------------------------------------------------|

--- a/docs/sources/vendor/Pulse/connectsecure.md
+++ b/docs/sources/vendor/Pulse/connectsecure.md
@@ -3,7 +3,7 @@
 ## Key facts
 
 * Requires vendor product by source configuration
-* IETF Frames use port 601/tcp or 6587/TLS
+* IETF Frames use port 601/tcp or 5425/TLS
 
 ## Links 
 

--- a/docs/sources/vendor/Tanium/platform.md
+++ b/docs/sources/vendor/Tanium/platform.md
@@ -6,7 +6,7 @@ The source is understood to require a valid certificate.
 ## Key facts
 
 * MSG Format based filter
-* Requires TLS and uses IETF Frames use port 6587 after TLS Configuration
+* Requires TLS and uses IETF Frames use port 5425 after TLS Configuration
 
 ## Links
 


### PR DESCRIPTION
Updating the vendor documentation with the correct port number (5425) for TLS framed logs.