### PR TITLE
docs: update missing link in getting started

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -17,7 +17,7 @@ or resource constraint can cause data to be lost in transmission.
 * If you reguire high availability for SC4S, implement multi-node clustering.
 * Avoid TCP except where the source is unable to contain the event to a single UDP packet.
 * Avoid TLS except where the event may cross an untrusted network.
-* Plan for [appropriately sized hardware](../performance.md)
+* Plan for [appropriately sized hardware](../architecture/performance-tests.md)
 
 
 ## Implementation


### PR DESCRIPTION
Update the link to performance tests after they were moved to architecture.