### PR TITLE
fix: update mapping for cisco ftd sourcetype

### DIFF
--- a/package/enterprise/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_asa.conf
+++ b/package/enterprise/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_asa.conf
@@ -14,11 +14,7 @@ block parser app-cisco-cisco_asa() {
 };
 application app-cisco-cisco_asa[cisco_syslog] {
 	filter {
-        message('%ASA-' type(string) flags(prefix))
-        or (
-            message('%FTD-' type(string) flags(prefix))
-            and not "${.values.mnemonic}" eq "430003"
-        );
+        message('%ASA-' type(string) flags(prefix));
     };	
     parser { app-cisco-cisco_asa(); };
 };

--- a/package/enterprise/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_ftd.conf
+++ b/package/enterprise/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_ftd.conf
@@ -13,9 +13,7 @@ block parser app-cisco-cisco_ftd() {
 };
 application app-cisco-cisco_ftd[cisco_syslog] {
 	filter {
-        message('%FTD-' type(string) flags(prefix))
-        and "${.values.mnemonic}" eq "430003"
-        ;
+        message('%FTD-' type(string) flags(prefix));
     };	
     parser { app-cisco-cisco_ftd(); };
 };

--- a/package/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_asa.conf
+++ b/package/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_asa.conf
@@ -14,11 +14,7 @@ block parser app-cisco-cisco_asa() {
 };
 application app-cisco-cisco_asa[cisco_syslog] {
 	filter {
-        message('%ASA-' type(string) flags(prefix))
-        or (
-            message('%FTD-' type(string) flags(prefix))
-            and not "${.values.mnemonic}" eq "430003"
-        );
+        message('%ASA-' type(string) flags(prefix));
     };	
     parser { app-cisco-cisco_asa(); };
 };

--- a/package/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_ftd.conf
+++ b/package/etc/conf.d/conflib/cisco-syslog/app-cisco-cisco_ftd.conf
@@ -13,9 +13,7 @@ block parser app-cisco-cisco_ftd() {
 };
 application app-cisco-cisco_ftd[cisco_syslog] {
 	filter {
-        message('%FTD-' type(string) flags(prefix))
-        and "${.values.mnemonic}" eq "430003"
-        ;
+        message('%FTD-' type(string) flags(prefix));
     };	
     parser { app-cisco-cisco_ftd(); };
 };

--- a/package/lite/etc/addons/cisco/app-cisco-cisco_asa.conf
+++ b/package/lite/etc/addons/cisco/app-cisco-cisco_asa.conf
@@ -15,10 +15,6 @@ block parser app-cisco-cisco_asa() {
 application app-cisco-cisco_asa[cisco_syslog] {
 	filter {
         message('%ASA-' type(string) flags(prefix))
-        or (
-            message('%FTD-' type(string) flags(prefix))
-            and not "${.values.mnemonic}" eq "430003"
-        );
     };	
     parser { app-cisco-cisco_asa(); };
 };

--- a/package/lite/etc/addons/cisco/app-cisco-cisco_ftd.conf
+++ b/package/lite/etc/addons/cisco/app-cisco-cisco_ftd.conf
@@ -13,9 +13,7 @@ block parser app-cisco-cisco_ftd() {
 };
 application app-cisco-cisco_ftd[cisco_syslog] {
 	filter {
-        message('%FTD-' type(string) flags(prefix))
-        and "${.values.mnemonic}" eq "430003"
-        ;
+        message('%FTD-' type(string) flags(prefix));
     };	
     parser { app-cisco-cisco_ftd(); };
 };


### PR DESCRIPTION
Updated regex based mapping for cisco ftd sourcetype, to allow FTD type data to fall under cisco:ftd sourcetype.