### PR TITLE
fix: update requests and urllib3 to fix vulnerabilities

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1376,19 +1376,19 @@ pyyaml = "*"
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 
@@ -1558,14 +1558,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]
@@ -1712,4 +1712,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.9.0,<3.9.1 || >3.9.1,<4.0"
-content-hash = "52b95a24ee4b749f603ad3e34b3d19db1b26e4334a325d7d2bfce20310b68910"
+content-hash = "9190f7d02ff3dcc08f76be5de59191cbf80426539e8efbefd041c37bf220135d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">3.9.0,<3.9.1 || >3.9.1,<4.0"
 Jinja2 = "^3.1.3"
-requests = "^2.28.1"
+requests = "^2.32.5"
 shortuuid = "^1.0.11"
 pyyaml = "6.0.2"
 setuptools = "^78.0.0"


### PR DESCRIPTION
Jira: https://splunk.atlassian.net/browse/ADDON-83246

- Upgrades requests to 2.32.5
- Upgrades urllib to 2.5.0
-  This fixes VULNS : https://splunk.atlassian.net/browse/VULN-41611 and https://splunk.atlassian.net/browse/VULN-41610 