### PR TITLE
fix: avoid double --no-caps cli option for syslog-ng

### DIFF
--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -249,7 +249,7 @@ done
 export SC4S_VERSION=$(cat $SC4S_ETC/VERSION)
 echo sc4s version=$(cat $SC4S_ETC/VERSION)
 echo sc4s version=$(cat $SC4S_ETC/VERSION) >>$SC4S_VAR/log/syslog-ng.out
-"${SC4S_SBIN}"/syslog-ng --no-caps $SC4S_CONTAINER_OPTS -s >>$SC4S_VAR/log/syslog-ng.out 2>$SC4S_VAR/log/syslog-ng.err
+"${SC4S_SBIN}"/syslog-ng $SC4S_CONTAINER_OPTS -s >>$SC4S_VAR/log/syslog-ng.out 2>$SC4S_VAR/log/syslog-ng.err
 
 echo "Configuring the health check port to: $SC4S_LISTEN_STATUS_PORT"
 nohup gunicorn -b 0.0.0.0:$SC4S_LISTEN_STATUS_PORT healthcheck:app &
@@ -281,9 +281,9 @@ do
   echo starting syslog-ng
   if [ "${SC4S_DEBUG_LOGS}" == "yes" ]; then
     echo debug mode enabled
-    "${SC4S_SBIN}"/syslog-ng --no-caps -d -v -e "${SC4S_CONTAINER_OPTS}" -F "${@}" &
+    "${SC4S_SBIN}"/syslog-ng -d -v -e "${SC4S_CONTAINER_OPTS}" -F "${@}" &
   else
-    "${SC4S_SBIN}"/syslog-ng --no-caps "${SC4S_CONTAINER_OPTS}" -F "${@}" &
+    "${SC4S_SBIN}"/syslog-ng "${SC4S_CONTAINER_OPTS}" -F "${@}" &
   fi
   pid="$!"
   sleep 2


### PR DESCRIPTION
Currently --no-caps is set twice, once in package/sbin/entrypoint.sh once in SC4S_CONTAINER_OPTS inside package/Dockerfile*

I've removed it in entrypoint so it gets set via SC4S_CONTAINER_OPTS and is overwriteable if anyone choses to do so.