### PR TITLE
feat: add SNI configuration option for HEC TLS destinations

### DIFF
--- a/docs/destinations.md
+++ b/docs/destinations.md
@@ -20,6 +20,7 @@ You can configure Splunk Connect for Syslog to use any destination available in 
 | SC4S_DEST_SPLUNK_HEC_&lt;ID&gt;_MODE | string | "GLOBAL" or "SELECT". |
 | SC4S_DEST_SPLUNK_HEC_&lt;ID&gt;_TLS_VERIFY | yes(default) or no | Verify HTTP(s) certificates. |
 | SC4S_DEST_SPLUNK_HEC_&lt;ID&gt;_HTTP_COMPRESSION       | yes or no(default) | Compress outgoing HTTP traffic using the gzip method. |
+| SC4S_DEST_SPLUNK_HEC_&lt;ID&gt;_SNI       | yes or no(default) | Enable TLS Server Name Indication (SNI). When enabled, SC4S sends the HEC destination hostname during the TLS handshake, which allows SSL/TLS passthrough load balancers to make routing decisions based on the target hostname. |
 
 ## HTTP Compression
 

--- a/package/etc/conf.d/destinations/dest_hec/plugin.jinja
+++ b/package/etc/conf.d/destinations/dest_hec/plugin.jinja
@@ -44,6 +44,9 @@ destination d_hec{{ dest_mode }}{{ altname }}{
         {%- if ssl_version %}
             ssl-version("{{ ssl_version }}")
         {%- endif %}
+        {%- if sni %}
+            sni(yes)
+        {%- endif %}
         )
         use-system-cert-store(yes)
         body('{{ msg_template }}')

--- a/package/etc/conf.d/destinations/dest_hec/plugin.py
+++ b/package/etc/conf.d/destinations/dest_hec/plugin.py
@@ -144,6 +144,7 @@ for group in dests:
         peer_verify=os.getenv(f"SC4S_DEST_SPLUNK_HEC_{group}_TLS_VERIFY", "yes"),
         cipher_suite=os.getenv(f"SC4S_DEST_SPLUNK_HEC_{group}_CIPHER_SUITE"),
         ssl_version=os.getenv(f"SC4S_DEST_SPLUNK_HEC_{group}_SSL_VERSION"),
+        sni=os.getenv(f"SC4S_DEST_SPLUNK_HEC_{group}_SNI", "no").lower() in ["true", "1", "t", "y", "yes"],
         http_compression=http_compression
     )
 


### PR DESCRIPTION
Add SC4S_DEST_SPLUNK_HEC_<ID>_SNI env var to enable TLS Server Name Indication on HEC destinations. This allows SSL/TLS passthrough load balancers to route HTTPS traffic based on the target hostname sent during the TLS handshake.

Made-with: Cursor