### PR TITLE
fix: clasify sshd(pam_audit) events as f5 bigip

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-f5_bigip.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-f5_bigip.conf
@@ -64,7 +64,7 @@ block parser app-syslog-f5_bigip() {
                 or program('mcpd' type(string) flags(prefix))
                 or program('mprov' type(string) flags(prefix))
                 or program('apmd' type(string) flags(prefix))
-                or program('sshd\(pam_audit\)')
+                or program('sshd(pam_audit)' type(string) flags(prefix))
                 or message('pam_radius_auth|authenticated|pam_bigip_authz|mod_auth_pam')
                 );
             };
@@ -88,6 +88,7 @@ application app-syslog-f5_bigip[sc4s-syslog-pgm] {
             or program('mprov' type(string) flags(prefix))
             or program('apmd' type(string) flags(prefix))
             or program('tmm' type(string) flags(prefix))
+            or program('sshd(pam_audit)' type(string) flags(prefix))
             or (program('F5' type(string) flags(prefix)) and not match('access_json' value('MSGID')))
         )
         ;

--- a/package/lite/etc/addons/f5/app-syslog-f5_bigip.conf
+++ b/package/lite/etc/addons/f5/app-syslog-f5_bigip.conf
@@ -64,7 +64,7 @@ block parser app-syslog-f5_bigip() {
                 or program('mcpd' type(string) flags(prefix))
                 or program('mprov' type(string) flags(prefix))
                 or program('apmd' type(string) flags(prefix))
-                or program('sshd\(pam_audit\)')
+                or program('sshd(pam_audit)' type(string) flags(prefix))
                 or message('pam_radius_auth|authenticated|pam_bigip_authz|mod_auth_pam')
                 );
             };
@@ -88,6 +88,7 @@ application app-syslog-f5_bigip[sc4s-syslog-pgm] {
             or program('mprov' type(string) flags(prefix))
             or program('apmd' type(string) flags(prefix))
             or program('tmm' type(string) flags(prefix))
+            or program('sshd(pam_audit)' type(string) flags(prefix))
             or (program('F5' type(string) flags(prefix)) and not match('access_json' value('MSGID')))
         )
         ;


### PR DESCRIPTION
Fix for issue: https://github.com/splunk/splunk-connect-for-syslog/issues/3013. Added sshd(pam_audit) to filter for f5 bigip parser