### PR TITLE
fix: removed tls compression option

### DIFF
--- a/package/etc/conf.d/sources/source_syslog/plugin.jinja
+++ b/package/etc/conf.d/sources/source_syslog/plugin.jinja
@@ -91,7 +91,6 @@ source s_{{ port_id }} {
                 chain-hostnames(off)
                 flags(validate-utf8, no-parse {%- if store_raw_message %} store-raw-message{% endif %})
                 tls(
-                    allow-compress(yes)
                     key-file("{{ tls_dir }}/{{ key_file }}")
                     cert-file("{{ tls_dir }}/{{ cert_file }}")
                     ssl-options({{ port_tls_tls_options }})
@@ -391,7 +390,6 @@ source s_{{ port_id }} {
                 chain-hostnames(off)
                 flags(validate-utf8)
                 tls(
-                    allow-compress(yes)
                     key-file("{{ tls_dir }}/{{ key_file }}")
                     cert-file("{{ tls_dir }}/{{ cert_file }}")
                     ssl-options({{ port_5425_tls_options }})


### PR DESCRIPTION
Issue mentioned here:
https://github.com/splunk/splunk-connect-for-syslog/issues/3093

This option was deprecated in this release (via increasing the default security level): 
https://openssl-library.org/news/openssl-3.2-notes/
https://docs.openssl.org/3.2/man3/SSL_CTX_set_security_level/

We could potentially put an option to enable this manually (but it also requires to lower the security level) but it doesn't seem very useful imo