### PR TITLE
Feat/mcp multi client support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,34 @@ sudo systemctl restart sc4s
 
 The MCP server's configuration and metadata tools also require `SC4S_API_MANAGEMENT_ENABLED=true` on the SC4S side; without it, those tools will receive HTTP 404 responses from the SC4S API.
 
+### Asynchronous configuration jobs
+
+Configuration-changing POST and DELETE requests validate their input and then
+return `202 Accepted` with a job ID. The `Location` header points to
+`/jobs/<job_id>`:
+
+```json
+{"status": "success", "job_id": "c91e0d50-0f84-4aec-9788-86133e0da8e5"}
+```
+
+Poll the location until the job changes from `in_progress` to `success` or
+`failed`. Successful jobs include the operation's original response under
+`result`; failed jobs include an `error` message.
+
+Only one configuration job runs at a time. A valid request received while a
+job is running returns `409 Conflict` and identifies the active job:
+
+```json
+{
+  "status": "error",
+  "message": "Another configuration job is in progress",
+  "active_job": {
+    "job_id": "c91e0d50-0f84-4aec-9788-86133e0da8e5",
+    "url": "/jobs/c91e0d50-0f84-4aec-9788-86133e0da8e5"
+  }
+}
+```
+
 ## SC4S management API TLS
 
 The management API supports optional TLS. When enabled, the API serves
@@ -468,7 +496,6 @@ This feature can be used with `SC4S_PARALLELIZE_NO_PARTITION`.
 |----------|---------------|-------------|
 | SC4S_ENABLE_PARALLELIZE=yes  | yes or no(default) | Use parallelize to leverage multithreading when consuming from a single TCP connection. |
 |SC4S_PARALLELIZE_NO_PARTITION=4 | Integer | Set the number of threads to use, the default value is 4. |
-
 
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ return `202 Accepted` with a job ID. The `Location` header points to
 `/jobs/<job_id>`:
 
 ```json
-{"status": "success", "job_id": "c91e0d50-0f84-4aec-9788-86133e0da8e5"}
+{"status": "accepted", "job_id": "c91e0d50-0f84-4aec-9788-86133e0da8e5"}
 ```
 
 Poll the location until the job changes from `in_progress` to `success` or
@@ -496,6 +496,5 @@ This feature can be used with `SC4S_PARALLELIZE_NO_PARTITION`.
 |----------|---------------|-------------|
 | SC4S_ENABLE_PARALLELIZE=yes  | yes or no(default) | Use parallelize to leverage multithreading when consuming from a single TCP connection. |
 |SC4S_PARALLELIZE_NO_PARTITION=4 | Integer | Set the number of threads to use, the default value is 4. |
-
 
 

--- a/docs/mcp_server/tools.md
+++ b/docs/mcp_server/tools.md
@@ -46,8 +46,9 @@ instead of a failure inside your SC4S container.
 | Tool | Description |
 |---|---|
 | `sc4s_health()` | Returns the health payload from the SC4S management API. Use this first when troubleshooting. |
+| `get_job_status(job_id)` | Polls a configuration job until its status is `success` or `failed`. |
 | `get_env()` | Reads the current `env_file` from the running SC4S instance. |
-| `set_env(env_file_content)` | Uploads a new `env_file`. The SC4S API backs up the previous file, applies the new one, and restarts `syslog-ng`. On validation failure the previous file is restored. |
+| `set_env(env_file_content)` | Uploads a new `env_file` and returns an asynchronous job ID. |
 
 ### Custom parsers
 
@@ -55,8 +56,8 @@ instead of a failure inside your SC4S container.
 |---|---|
 | `list_custom_parsers()` | Lists all custom parsers currently deployed on the SC4S instance. |
 | `get_custom_parser(name)` | Reads the content of a deployed custom parser. |
-| `add_parser(filename, content)` | Uploads a new `.conf` parser. The `.conf` extension is added if missing. SC4S validates syntax and restarts `syslog-ng`; invalid parsers are rolled back. |
-| `delete_parser(name)` | Deletes a custom parser. SC4S re-validates the remaining configuration and restarts `syslog-ng`; if validation fails, the parser is restored. |
+| `add_parser(filename, content)` | Uploads a new `.conf` parser and returns an asynchronous job ID. |
+| `delete_parser(name)` | Deletes a custom parser and returns an asynchronous job ID. |
 
 ### Splunk metadata (`splunk_metadata.csv`)
 
@@ -66,8 +67,8 @@ These tools manage per-vendor/product overrides that SC4S sends to Splunk
 | Tool | Description                                                                                                                                                                                            |
 |---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `get_splunk_metadata()` | Reads `splunk_metadata.csv` entries. Each entry is `{ key, metadata, value }`, where `metadata` is one of `index, source, sourcetype, host, sc4s_template` and `key` is a `vendor_product` identifier. |
-| `set_splunk_metadata(entries)` | Overwrites `splunk_metadata.csv` with the provided list. SC4S restarts after applying. Example entry: `{"key": "juniper_netscreen", "metadata": "index", "value": "ns_index"}`.                        |
-| `delete_splunk_metadata()` | Clears all Splunk metadata overrides. SC4S restarts after clearing.                                                                                                                                    |
+| `set_splunk_metadata(entries)` | Overwrites `splunk_metadata.csv` and returns an asynchronous job ID. Example entry: `{"key": "juniper_netscreen", "metadata": "index", "value": "ns_index"}`. |
+| `delete_splunk_metadata()` | Clears all Splunk metadata overrides and returns an asynchronous job ID. |
 
 ### Compliance metadata (`compliance_meta_by_source`)
 
@@ -78,8 +79,16 @@ host, IP, or subnet matching.
 | Tool | Description |
 |---|---|
 | `get_compliance_overrides()` | Reads both the `.conf` filter definitions (`conf_content`) and the CSV rows (`csv_content`). |
-| `set_compliance_override(conf_content, csv_content)` | Overwrites both files. `csv_content` is a list of `{filter_name, field_name, value}` dicts, where `field_name` must be `.splunk.index`, `.splunk.source`, `.splunk.sourcetype`, or `fields.<name>`. SC4S restarts after applying. |
-| `delete_compliance_override()` | Clears both files, removing all compliance overrides. SC4S restarts after clearing. |
+| `set_compliance_override(conf_content, csv_content)` | Overwrites both files and returns an asynchronous job ID. `field_name` must be `.splunk.index`, `.splunk.source`, `.splunk.sourcetype`, or `fields.<name>`. |
+| `delete_compliance_override()` | Clears both files and returns an asynchronous job ID. |
+
+Any tool that modifies the SC4S configuration returns the ID of the job
+performing the update. Call `get_job_status(job_id)` to check whether the job
+is `in_progress`, `success`, or `failed`.
+
+If you try to start another job while one is already running, the API returns
+HTTP `409 Conflict` with details about the active job. Wait for that job to
+finish before retrying.
 
 Example `conf_content`:
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -103,6 +103,8 @@ COPY package/sbin/config_api.py /
 COPY package/sbin/metadata_api.py /
 COPY package/sbin/constants.py /
 COPY package/sbin/utils.py /
+COPY package/sbin/job_manager.py /
+COPY package/sbin/job_api.py /
 COPY package/sbin/source_ports_validator.py /
 COPY package/sbin/tls.py /
 COPY package/sbin/gunicorn_config.py /

--- a/package/Dockerfile.lite
+++ b/package/Dockerfile.lite
@@ -129,6 +129,8 @@ COPY package/sbin/config_api.py /
 COPY package/sbin/metadata_api.py /
 COPY package/sbin/constants.py /
 COPY package/sbin/utils.py /
+COPY package/sbin/job_manager.py /
+COPY package/sbin/job_api.py /
 COPY package/sbin/source_ports_validator.py /
 COPY package/sbin/tls.py /
 COPY package/sbin/gunicorn_config.py /

--- a/package/sbin/api.py
+++ b/package/sbin/api.py
@@ -6,6 +6,7 @@ from flask import Flask, jsonify, request
 from config_api import config_bp, csrf
 from healthcheck import healthcheck_bp, str_to_bool
 from metadata_api import metadata_bp
+from job_api import init_job_manager, job_bp
 from auth import build_token_verify
 from tls import tls_is_enabled
 
@@ -28,6 +29,8 @@ if management_enabled:
     app.register_blueprint(config_bp)
     csrf.exempt(metadata_bp)
     app.register_blueprint(metadata_bp)
+    init_job_manager(app)
+    app.register_blueprint(job_bp)
     logger.info(
         "Management API endpoints enabled (%s=true): /config/* routes registered",
         MANAGEMENT_ENABLED_ENV,

--- a/package/sbin/config_api.py
+++ b/package/sbin/config_api.py
@@ -4,6 +4,7 @@ from flask_wtf.csrf import CSRFProtect
 from flask import Blueprint, jsonify, request
 
 from constants import ENV_FILE, PARSERS_DIR
+from job_api import submit_job
 from utils import apply_with_rollback
 
 logger = logging.getLogger(__name__)
@@ -35,12 +36,13 @@ def set_env():
     if not file.filename:
         return jsonify({"status": "error", "message": "empty file"}), 400
 
-    try:
-        apply_with_rollback({ENV_FILE: file.read().decode("utf-8")})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+    content = file.read().decode("utf-8")
 
-    return jsonify({"status": "env_file updated successfully"}), 200
+    def apply_env():
+        apply_with_rollback({ENV_FILE: content})
+        return {"status": "env_file updated successfully"}
+
+    return submit_job(apply_env)
 
 
 @csrf.exempt
@@ -54,15 +56,13 @@ def add_parser():
         return jsonify({"status": "error", "message": "file must be a .conf file"}), 400
 
     parser_path = PARSERS_DIR / file.filename
+    content = file.read().decode("utf-8")
 
-    try:
-        apply_with_rollback({parser_path: file.read().decode("utf-8")})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+    def apply_parser():
+        apply_with_rollback({parser_path: content})
+        return {"status": "parser added successfully", "path": str(parser_path)}
 
-    return jsonify(
-        {"status": "parser added successfully", "path": str(parser_path)}
-    ), 200
+    return submit_job(apply_parser)
 
 
 @config_bp.route("/config/parser/<name>", methods=["GET"])
@@ -92,12 +92,11 @@ def delete_parser(name):
     if not parser_path.exists():
         return jsonify({"status": "error", "message": "parser not found"}), 404
 
-    try:
+    def remove_parser():
         apply_with_rollback({parser_path: None})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+        return {"status": "parser deleted successfully"}
 
-    return jsonify({"status": "parser deleted successfully"}), 200
+    return submit_job(remove_parser)
 
 
 @config_bp.route("/config/parsers", methods=["GET"])

--- a/package/sbin/config_api.py
+++ b/package/sbin/config_api.py
@@ -36,7 +36,10 @@ def set_env():
     if not file.filename:
         return jsonify({"status": "error", "message": "empty file"}), 400
 
-    content = file.read().decode("utf-8")
+    try:
+        content = file.read().decode("utf-8")
+    except UnicodeDecodeError:
+        return jsonify({"status": "error", "message": "invalid file"}), 400
 
     def apply_env():
         apply_with_rollback({ENV_FILE: content})

--- a/package/sbin/entrypoint.sh
+++ b/package/sbin/entrypoint.sh
@@ -263,7 +263,7 @@ echo sc4s version=$(cat $SC4S_ETC/VERSION) >>$SC4S_VAR/log/syslog-ng.out
 "${SC4S_SBIN}"/syslog-ng $SC4S_CONTAINER_OPTS -s >>$SC4S_VAR/log/syslog-ng.out 2>$SC4S_VAR/log/syslog-ng.err
 
 echo "Configuring the health check port to: $SC4S_LISTEN_STATUS_PORT"
-nohup gunicorn -b 0.0.0.0:$SC4S_LISTEN_STATUS_PORT --config python:gunicorn_config api:app &
+nohup gunicorn -b 0.0.0.0:$SC4S_LISTEN_STATUS_PORT --workers 1 --config python:gunicorn_config api:app &
 
 # Generating syslog configuration and export it to tmp file
 # OPTIONAL for BYOE:  Comment out/remove all remaining lines and launch syslog-ng directly from systemd

--- a/package/sbin/gunicorn_config.py
+++ b/package/sbin/gunicorn_config.py
@@ -4,6 +4,13 @@ from tls import TlsConfigError, build_gunicorn_ssl_kwargs
 
 
 def on_starting(server):
+    if server.cfg.workers != 1:
+        server.log.error(
+            "Management API requires workers=1 (in-process job manager); got %s",
+            server.cfg.workers,
+        )
+        sys.exit(1)
+
     try:
         ssl_kwargs = build_gunicorn_ssl_kwargs()
     except TlsConfigError as exc:

--- a/package/sbin/job_api.py
+++ b/package/sbin/job_api.py
@@ -45,7 +45,17 @@ def submit_job(work: Callable[[], dict]):
             409,
         )
     except JobSubmissionError as exc:
-        return jsonify({"status": "error", "message": str(exc)}), 500
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": str(exc),
+                    "job_id": exc.job_id,
+                    "url": _get_status_url(exc.job_id),
+                }
+            ),
+            500,
+        )
 
     url = _get_status_url(job.job_id)
     response = jsonify({"status": "success", "job_id": job.job_id})
@@ -57,7 +67,7 @@ def submit_job(work: Callable[[], dict]):
 @job_bp.route("/jobs/<job_id>", methods=["GET"])
 def get_job_status(job_id: str):
     job_manager = get_job_manager()
-    job = job_manager.get_job(job_id)
+    job = job_manager.get_job_dict(job_id)
     if job is None:
         return jsonify({"status": "error", "message": "Job not found"}), 404
-    return jsonify(job.to_dict()), 200
+    return jsonify(job), 200

--- a/package/sbin/job_api.py
+++ b/package/sbin/job_api.py
@@ -1,0 +1,63 @@
+from typing import Callable
+
+from flask import Flask, current_app, Blueprint, jsonify, url_for
+
+from job_manager import JobConflict, JobManager, JobSubmissionError
+
+JOB_MANAGER_EXTENSION = "sc4s_job_manager"
+
+job_bp = Blueprint("jobs", __name__)
+
+
+def init_job_manager(
+    app: Flask,
+    manager: JobManager | None = None,
+) -> JobManager:
+    manager = manager or JobManager()
+    app.extensions[JOB_MANAGER_EXTENSION] = manager
+    return manager
+
+
+def get_job_manager() -> JobManager:
+    return current_app.extensions[JOB_MANAGER_EXTENSION]
+
+
+def _get_status_url(job_id: str) -> str:
+    return url_for("jobs.get_job_status", job_id=job_id)
+
+
+def submit_job(work: Callable[[], dict]):
+    job_manager = get_job_manager()
+    try:
+        job = job_manager.run_update(work)
+    except JobConflict as exc:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": "Another configuration job is in progress",
+                    "active_job": {
+                        "job_id": exc.active_job.job_id,
+                        "url": _get_status_url(exc.active_job.job_id),
+                    },
+                }
+            ),
+            409,
+        )
+    except JobSubmissionError as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+    url = _get_status_url(job.job_id)
+    response = jsonify({"status": "success", "job_id": job.job_id})
+    response.headers["Location"] = url
+    response.status_code = 202
+    return response
+
+
+@job_bp.route("/jobs/<job_id>", methods=["GET"])
+def get_job_status(job_id: str):
+    job_manager = get_job_manager()
+    job = job_manager.get_job(job_id)
+    if job is None:
+        return jsonify({"status": "error", "message": "Job not found"}), 404
+    return jsonify(job.to_dict()), 200

--- a/package/sbin/job_api.py
+++ b/package/sbin/job_api.py
@@ -58,7 +58,7 @@ def submit_job(work: Callable[[], dict]):
         )
 
     url = _get_status_url(job.job_id)
-    response = jsonify({"status": "success", "job_id": job.job_id})
+    response = jsonify({"status": "accepted", "job_id": job.job_id})
     response.headers["Location"] = url
     response.status_code = 202
     return response

--- a/package/sbin/job_manager.py
+++ b/package/sbin/job_manager.py
@@ -1,0 +1,112 @@
+from collections import OrderedDict
+from concurrent.futures import Executor, ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import Enum, auto
+import logging
+from threading import Lock
+from typing import Callable
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+
+class JobStatus(Enum):
+    SUCCESS = auto()
+    FAILED = auto()
+    IN_PROGRESS = auto()
+
+
+@dataclass
+class UpdateJob:
+    job_id: str
+    status: JobStatus
+    result: dict | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        payload = {
+            "job_id": self.job_id,
+            "status": self.status.name.lower(),
+        }
+        if self.result is not None:
+            payload["result"] = self.result
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+class JobConflict(Exception):
+    def __init__(self, active_job: UpdateJob):
+        super().__init__("Another update job is in progress")
+        self.active_job = active_job
+
+
+class JobSubmissionError(Exception):
+    def __init__(self, job: UpdateJob):
+        super().__init__("Job submission failed")
+        self.job_id = job.job_id
+
+
+class JobManager:
+    def __init__(
+        self,
+        max_history: int = 100,
+        executor: Executor | None = None,
+    ):
+        self._max_history = max_history
+        self._jobs: OrderedDict[str, UpdateJob] = OrderedDict()
+        self._lock = Lock()
+        self._executor = executor or ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="sc4s_job_manager",
+        )
+        self._active_job: UpdateJob | None = None
+
+    def run_update(self, work: Callable[[], dict]) -> UpdateJob:
+        with self._lock:
+            if self._active_job is not None:
+                raise JobConflict(self._active_job)
+
+            job = UpdateJob(job_id=str(uuid4()), status=JobStatus.IN_PROGRESS)
+            self._jobs[job.job_id] = job
+            self._active_job = job
+            self._evict_oldest_job()
+
+        try:
+            self._executor.submit(self._run, job, work)
+        except Exception as exc:
+            self._finish_job(job, JobStatus.FAILED, error=str(exc))
+            raise JobSubmissionError(job) from exc
+
+        return job
+
+    def get_job(self, job_id: str) -> UpdateJob | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def _run(self, job: UpdateJob, work: Callable[[], dict]):
+        try:
+            result = work()
+        except Exception as exc:
+            logger.exception("Update job %s failed", job.job_id)
+            self._finish_job(job, JobStatus.FAILED, error=str(exc))
+        else:
+            self._finish_job(job, JobStatus.SUCCESS, result=result)
+
+    def _finish_job(
+        self,
+        job: UpdateJob,
+        status: JobStatus,
+        result: dict | None = None,
+        error: str | None = None,
+    ):
+        with self._lock:
+            job.status = status
+            job.result = result
+            job.error = error
+            if self._active_job is job:
+                self._active_job = None
+
+    def _evict_oldest_job(self):
+        while len(self._jobs) > self._max_history:
+            self._jobs.popitem(last=False)

--- a/package/sbin/job_manager.py
+++ b/package/sbin/job_manager.py
@@ -84,6 +84,12 @@ class JobManager:
         with self._lock:
             return self._jobs.get(job_id)
 
+    def get_job_dict(self, job_id: str) -> dict | None:
+        """Serialize a job while holding the lock to avoid torn reads."""
+        with self._lock:
+            job = self._jobs.get(job_id)
+            return job.to_dict() if job is not None else None
+
     def _run(self, job: UpdateJob, work: Callable[[], dict]):
         try:
             result = work()

--- a/package/sbin/metadata_api.py
+++ b/package/sbin/metadata_api.py
@@ -12,6 +12,7 @@ from constants import (
     SPLUNK_METADATA_CSV,
     SPLUNK_METADATA_FIELDS,
 )
+from job_api import submit_job
 from utils import apply_with_rollback, read_three_col_csv
 
 
@@ -63,12 +64,13 @@ def set_splunk_metadata():
     for entry in entries:
         writer.writerow([entry["key"], entry["metadata"], entry["value"]])
 
-    try:
-        apply_with_rollback({SPLUNK_METADATA_CSV: buf.getvalue()})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+    files_to_write = {SPLUNK_METADATA_CSV: buf.getvalue()}
 
-    return jsonify({"status": "metadata updated successfully", "entries": entries}), 200
+    def apply_metadata():
+        apply_with_rollback(files_to_write)
+        return {"status": "metadata updated successfully", "entries": entries}
+
+    return submit_job(apply_metadata)
 
 
 @metadata_bp.route("/config/metadata/splunk", methods=["DELETE"])
@@ -78,12 +80,11 @@ def delete_splunk_metadata():
             {"status": "error", "message": "splunk_metadata.csv not found"}
         ), 404
 
-    try:
+    def clear_metadata():
         apply_with_rollback({SPLUNK_METADATA_CSV: ""})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+        return {"status": "splunk_metadata.csv cleared successfully"}
 
-    return jsonify({"status": "splunk_metadata.csv cleared successfully"}), 200
+    return submit_job(clear_metadata)
 
 
 # ---------------------------------------------------------------------------
@@ -159,12 +160,11 @@ def set_compliance():
             writer.writerow([entry["filter_name"], entry["field_name"], entry["value"]])
         files_to_write[COMPLIANCE_CSV] = buf.getvalue()
 
-    try:
+    def apply_compliance():
         apply_with_rollback(files_to_write)
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+        return {"status": "compliance metadata updated successfully"}
 
-    return jsonify({"status": "compliance metadata updated successfully"}), 200
+    return submit_job(apply_compliance)
 
 
 @metadata_bp.route("/config/metadata/compliance", methods=["DELETE"])
@@ -180,9 +180,8 @@ def delete_compliance():
     if COMPLIANCE_CSV.exists():
         files_to_write[COMPLIANCE_CSV] = ""
 
-    try:
+    def clear_compliance():
         apply_with_rollback(files_to_write)
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+        return {"status": "compliance metadata cleared successfully"}
 
-    return jsonify({"status": "compliance metadata cleared successfully"}), 200
+    return submit_job(clear_compliance)

--- a/package/sbin/utils.py
+++ b/package/sbin/utils.py
@@ -4,10 +4,14 @@ import logging
 from pathlib import Path
 import subprocess
 import shutil
+import time
 
 from constants import BACKUP_FILE, ENV_FILE
 
 logger = logging.getLogger(__name__)
+
+RESTART_TIMEOUT_SECONDS = 30
+RESTART_POLL_INTERVAL_SECONDS = 0.5
 
 
 def build_env_from_file():
@@ -26,8 +30,40 @@ def build_env_from_file():
     return env
 
 
+def _get_syslog_ng_pids() -> set[int]:
+    result = subprocess.run(
+        ["pgrep", "-x", "syslog-ng"],
+        capture_output=True,
+        text=True,
+        timeout=1,
+    )
+    if result.returncode == 1:
+        return set()
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to find syslog-ng processes: {result.stderr.strip()}"
+        )
+
+    return {int(pid) for pid in result.stdout.split()}
+
+
+def _syslog_ng_is_healthy() -> bool:
+    try:
+        result = subprocess.run(
+            ["syslog-ng-ctl", "healthcheck", "--timeout", "1"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+
+    return result.returncode == 0
+
+
 def restart_syslog_ng():
-    """Kill syslog-ng; the entrypoint while loop will restart it automatically."""
+    """Restart syslog-ng and wait for its replacement to become healthy."""
+    previous_pids = _get_syslog_ng_pids()
     result = subprocess.run(
         ["pkill", "syslog-ng"],
         capture_output=True,
@@ -36,6 +72,23 @@ def restart_syslog_ng():
     )
     if result.returncode != 0:
         raise RuntimeError(f"syslog-ng restart failed: {result.stderr.strip()}")
+
+    deadline = time.time() + RESTART_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        current_pids = _get_syslog_ng_pids()
+        if current_pids - previous_pids and _syslog_ng_is_healthy():
+            if time.time() < deadline:
+                return
+            break
+
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        time.sleep(min(RESTART_POLL_INTERVAL_SECONDS, remaining))
+
+    raise RuntimeError(
+        f"syslog-ng restart timed out after {RESTART_TIMEOUT_SECONDS} seconds"
+    )
 
 
 def rollback_env():

--- a/package/sbin/utils.py
+++ b/package/sbin/utils.py
@@ -152,8 +152,12 @@ def cleanup_backups_files(backups: list[tuple[Path, Path]]):
 
 
 def apply_with_rollback(files_to_write: dict[Path, str | None]):
-    """Write files (or delete if content is None), run syntax check + restart, rollback on failure."""
+    """Write files, validate and restart.
+
+    Restore both files and runtime on failure.
+    """
     backups = []
+    runtime_restart_started = False
     try:
         for path, content in files_to_write.items():
             backups.append((path, backup_file(path)))
@@ -163,10 +167,20 @@ def apply_with_rollback(files_to_write: dict[Path, str | None]):
                 path.write_text(content, encoding="utf-8")
 
         syntax_check()
+        runtime_restart_started = True
         restart_syslog_ng()
-    except Exception as e:
+    except Exception as apply_error:
         logger.exception("Apply failed, rolling back")
-        rollback(backups)
-        raise e
+        try:
+            rollback(backups)
+            if runtime_restart_started:
+                restart_syslog_ng()
+        except Exception as rollback_error:
+            logger.exception("Rollback failed")
+            raise RuntimeError(
+                f"configuration apply failed: {apply_error}; "
+                f"rollback failed: {rollback_error}"
+            ) from rollback_error
+        raise
     finally:
         cleanup_backups_files(backups)

--- a/package/sbin/utils.py
+++ b/package/sbin/utils.py
@@ -73,15 +73,15 @@ def restart_syslog_ng():
     if result.returncode != 0:
         raise RuntimeError(f"syslog-ng restart failed: {result.stderr.strip()}")
 
-    deadline = time.time() + RESTART_TIMEOUT_SECONDS
-    while time.time() < deadline:
+    deadline = time.monotonic() + RESTART_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
         current_pids = _get_syslog_ng_pids()
-        if current_pids - previous_pids and _syslog_ng_is_healthy():
-            if time.time() < deadline:
-                return
-            break
-
-        remaining = deadline - time.time()
+        replacement_is_healthy = (
+            bool(current_pids - previous_pids) and _syslog_ng_is_healthy()
+        )
+        remaining = deadline - time.monotonic()
+        if replacement_is_healthy and remaining > 0:
+            return
         if remaining <= 0:
             break
         time.sleep(min(RESTART_POLL_INTERVAL_SECONDS, remaining))

--- a/sc4s_mcp/tests/test_config_tools.py
+++ b/sc4s_mcp/tests/test_config_tools.py
@@ -8,6 +8,7 @@ from tools.configuration_tools import (
     get_parser,
     search_docs,
     sc4s_health,
+    get_job_status,
     set_env,
     get_env,
     add_parser,
@@ -190,6 +191,16 @@ def test_search_docs_invalid_regex():
 def test_sc4s_health(mock_req):
     sc4s_health()
     mock_req.assert_called_once_with("get", "/health", timeout=10)
+
+
+@patch("tools.configuration_tools._sc4s_request")
+def test_get_job_status(mock_req):
+    mock_req.return_value = {"job_id": "job-1", "status": "success"}
+
+    result = get_job_status("job-1")
+
+    assert result == {"job_id": "job-1", "status": "success"}
+    mock_req.assert_called_once_with("get", "/jobs/job-1", timeout=10)
 
 
 @patch("tools.configuration_tools._sc4s_request")

--- a/sc4s_mcp/tools/configuration_tools.py
+++ b/sc4s_mcp/tools/configuration_tools.py
@@ -101,8 +101,14 @@ def sc4s_health() -> dict:
 
 
 @mcp.tool
+def get_job_status(job_id: str) -> dict:
+    """Get the current state and result of an asynchronous configuration job."""
+    return _sc4s_request("get", f"/jobs/{job_id}", timeout=10)
+
+
+@mcp.tool
 def set_env(env_file_content: str) -> dict:
-    """Upload a new env_file to the running SC4S instance. Provide the full env_file content as a string. SC4S will backup the current env_file, apply the new one, and restart syslog-ng."""
+    """Upload an env_file and return a job ID for polling with get_job_status."""
     return _sc4s_request(
         "post",
         "/config/env",
@@ -119,7 +125,7 @@ def get_env() -> dict:
 
 @mcp.tool
 def add_parser(filename: str, content: str) -> dict:
-    """Upload a new parser .conf file to the running SC4S instance. SC4S will validate the syntax and restart syslog-ng. If syntax check fails, the parser is rolled back."""
+    """Upload a parser and return a job ID for polling with get_job_status."""
     if not filename.endswith(".conf"):
         filename += ".conf"
     return _sc4s_request(
@@ -132,7 +138,7 @@ def add_parser(filename: str, content: str) -> dict:
 
 @mcp.tool
 def delete_parser(name: str) -> dict:
-    """Delete a custom parser from the running SC4S instance. SC4S will validate the config after removal and restart syslog-ng. If validation fails, the parser is restored."""
+    """Delete a parser and return a job ID for polling with get_job_status."""
     return _sc4s_request("delete", f"/config/parser/{name}", timeout=30)
 
 

--- a/sc4s_mcp/tools/metadata_tools.py
+++ b/sc4s_mcp/tools/metadata_tools.py
@@ -21,7 +21,7 @@ def get_splunk_metadata() -> dict:
 
 @mcp.tool
 def set_splunk_metadata(entries: list[dict]) -> dict:
-    """Overwrite the splunk_metadata.csv on the running SC4S instance. Restarts SC4S.
+    """Overwrite Splunk metadata and return a job ID for polling.
     Example: [{"key": "juniper_netscreen", "metadata": "index", "value": "ns_index"}]"""
     return sc4s_request(
         "post",
@@ -33,7 +33,7 @@ def set_splunk_metadata(entries: list[dict]) -> dict:
 
 @mcp.tool
 def delete_splunk_metadata() -> dict:
-    """Clear the splunk_metadata.csv on the running SC4S instance. SC4S restarts after clearing."""
+    """Clear Splunk metadata and return a job ID for polling."""
     return sc4s_request("delete", "/config/metadata/splunk", timeout=30)
 
 
@@ -53,7 +53,7 @@ def get_compliance_overrides() -> dict:
 
 @mcp.tool
 def set_compliance_override(conf_content: str, csv_content: list[dict]) -> dict:
-    """Overwrite the compliance_meta_by_source conf and CSV files instance.
+    """Overwrite compliance metadata and return a job ID for polling.
     The provided content completely replaces both files. SC4S restarts after applying changes.
 
     Args:
@@ -73,5 +73,5 @@ def set_compliance_override(conf_content: str, csv_content: list[dict]) -> dict:
 
 @mcp.tool
 def delete_compliance_override() -> dict:
-    """Clear both compliance_meta_by_source files (conf and CSV), removing all compliance overrides. SC4S restarts after clearing."""
+    """Clear compliance metadata and return a job ID for polling."""
     return sc4s_request("delete", "/config/metadata/compliance", timeout=30)

--- a/tests/api/test_config_api.py
+++ b/tests/api/test_config_api.py
@@ -56,8 +56,9 @@ def test_get_env_not_found(client):
 # ---------------------------------------------------------------------------
 
 
+@patch("config_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("config_api.apply_with_rollback")
-def test_set_env(mock_apply, client, ctx_dir):
+def test_set_env(mock_apply, _mock_submit, client, ctx_dir):
     env_file = ctx_dir / "env_file"
     env_file.write_text("OLD=value\n")
 
@@ -67,7 +68,7 @@ def test_set_env(mock_apply, client, ctx_dir):
         content_type="multipart/form-data",
     )
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "updated successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
@@ -79,8 +80,9 @@ def test_set_env_no_file(client):
     assert "no file" in resp.get_json()["message"]
 
 
+@patch("config_api.submit_job", return_value=({"job_id": "job-1"}, 202))
 @patch("config_api.apply_with_rollback", side_effect=RuntimeError("restart failed"))
-def test_set_env_rollback_on_failure(mock_apply, client, ctx_dir):
+def test_set_env_rollback_on_failure(mock_apply, mock_submit, client, ctx_dir):
     env_file = ctx_dir / "env_file"
     env_file.write_text("ORIGINAL=value\n")
 
@@ -90,8 +92,9 @@ def test_set_env_rollback_on_failure(mock_apply, client, ctx_dir):
         content_type="multipart/form-data",
     )
 
-    assert resp.status_code == 500
-    assert "restart failed" in resp.get_json()["message"]
+    assert resp.status_code == 202
+    with pytest.raises(RuntimeError, match="restart failed"):
+        mock_submit.call_args.args[0]()
 
 
 # ---------------------------------------------------------------------------
@@ -99,15 +102,16 @@ def test_set_env_rollback_on_failure(mock_apply, client, ctx_dir):
 # ---------------------------------------------------------------------------
 
 
+@patch("config_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("config_api.apply_with_rollback")
-def test_add_parser(mock_apply, client, ctx_dir):
+def test_add_parser(mock_apply, _mock_submit, client, ctx_dir):
     resp = client.post(
         "/config/parser",
         data={"file": (BytesIO(b"block parser test {}"), "test.conf")},
         content_type="multipart/form-data",
     )
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "parser added successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
@@ -130,16 +134,20 @@ def test_add_parser_not_conf(client):
     assert ".conf" in resp.get_json()["message"]
 
 
+@patch("config_api.submit_job", return_value=({"job_id": "job-1"}, 202))
 @patch("config_api.apply_with_rollback", side_effect=RuntimeError("syntax error"))
-def test_add_parser_rollback_on_syntax_fail(mock_apply, client, ctx_dir):
+def test_add_parser_rollback_on_syntax_fail(
+    mock_apply, mock_submit, client, ctx_dir
+):
     resp = client.post(
         "/config/parser",
         data={"file": (BytesIO(b"bad content"), "bad.conf")},
         content_type="multipart/form-data",
     )
 
-    assert resp.status_code == 500
-    assert "syntax error" in resp.get_json()["message"]
+    assert resp.status_code == 202
+    with pytest.raises(RuntimeError, match="syntax error"):
+        mock_submit.call_args.args[0]()
 
 
 # ---------------------------------------------------------------------------
@@ -181,14 +189,15 @@ def test_get_parser_not_found(client):
 # ---------------------------------------------------------------------------
 
 
+@patch("config_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("config_api.apply_with_rollback")
-def test_delete_parser(mock_apply, client, ctx_dir):
+def test_delete_parser(mock_apply, _mock_submit, client, ctx_dir):
     parser_file = ctx_dir / "parsers" / "my_parser.conf"
     parser_file.write_text("block parser my_parser {}")
 
     resp = client.delete("/config/parser/my_parser.conf")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "deleted successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
@@ -200,15 +209,19 @@ def test_delete_parser_not_found(client):
     assert "not found" in resp.get_json()["message"]
 
 
+@patch("config_api.submit_job", return_value=({"job_id": "job-1"}, 202))
 @patch("config_api.apply_with_rollback", side_effect=RuntimeError("syntax error"))
-def test_delete_parser_rollback_on_failure(mock_apply, client, ctx_dir):
+def test_delete_parser_rollback_on_failure(
+    mock_apply, mock_submit, client, ctx_dir
+):
     parser_file = ctx_dir / "parsers" / "my_parser.conf"
     parser_file.write_text("block parser my_parser {}")
 
     resp = client.delete("/config/parser/my_parser.conf")
 
-    assert resp.status_code == 500
-    assert "syntax error" in resp.get_json()["message"]
+    assert resp.status_code == 202
+    with pytest.raises(RuntimeError, match="syntax error"):
+        mock_submit.call_args.args[0]()
 
 
 # ---------------------------------------------------------------------------
@@ -233,3 +246,56 @@ def test_list_parsers_empty(client):
 
     assert resp.status_code == 200
     assert resp.get_json()["parsers"] == []
+
+
+@patch("config_api.submit_job", return_value=({"job_id": "job-1"}, 202))
+@patch("config_api.apply_with_rollback")
+def test_set_env_submits_background_work(mock_apply, mock_submit, client, ctx_dir):
+    response = client.post(
+        "/config/env",
+        data={"file": (BytesIO(b"NEW=value\n"), "env_file")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "env_file updated successfully"}
+    mock_apply.assert_called_once_with({ctx_dir / "env_file": "NEW=value\n"})
+
+
+@patch("config_api.submit_job", return_value=({"job_id": "job-2"}, 202))
+@patch("config_api.apply_with_rollback")
+def test_add_parser_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    response = client.post(
+        "/config/parser",
+        data={"file": (BytesIO(b"block parser test {}"), "test.conf")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {
+        "status": "parser added successfully",
+        "path": str(ctx_dir / "parsers" / "test.conf"),
+    }
+    mock_apply.assert_called_once_with(
+        {ctx_dir / "parsers" / "test.conf": "block parser test {}"}
+    )
+
+
+@patch("config_api.submit_job", return_value=({"job_id": "job-3"}, 202))
+@patch("config_api.apply_with_rollback")
+def test_delete_parser_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    parser_file = ctx_dir / "parsers" / "my_parser.conf"
+    parser_file.write_text("block parser my_parser {}")
+
+    response = client.delete("/config/parser/my_parser.conf")
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "parser deleted successfully"}
+    mock_apply.assert_called_once_with({parser_file: None})

--- a/tests/api/test_job_api.py
+++ b/tests/api/test_job_api.py
@@ -77,4 +77,7 @@ def test_executor_submission_failure_returns_500():
     response = app.test_client().post("/submit")
 
     assert response.status_code == 500
-    assert response.get_json()["message"] == "Job submission failed"
+    body = response.get_json()
+    assert body["message"] == "Job submission failed"
+    assert body["job_id"]
+    assert body["url"] == f"/jobs/{body['job_id']}"

--- a/tests/api/test_job_api.py
+++ b/tests/api/test_job_api.py
@@ -1,0 +1,80 @@
+from flask import Flask
+
+from job_api import init_job_manager, job_bp, submit_job
+from job_manager import JobManager
+from test_jobs import DeferredExecutor, RejectingExecutor
+
+
+def create_app(manager: JobManager) -> Flask:
+    app = Flask(__name__)
+    init_job_manager(app, manager)
+    app.register_blueprint(job_bp)
+
+    @app.post("/submit")
+    def submit():
+        return submit_job(lambda: {"status": "updated"})
+
+    return app
+
+
+def test_submit_returns_202_with_job_id_and_location():
+    app = create_app(JobManager(executor=DeferredExecutor()))
+
+    response = app.test_client().post("/submit")
+
+    assert response.status_code == 202
+    assert response.get_json()["status"] == "success"
+    job_id = response.get_json()["job_id"]
+    assert response.headers["Location"] == f"/jobs/{job_id}"
+
+
+def test_conflict_identifies_active_job():
+    app = create_app(JobManager(executor=DeferredExecutor()))
+    client = app.test_client()
+    accepted = client.post("/submit")
+
+    conflict = client.post("/submit")
+
+    assert conflict.status_code == 409
+    assert conflict.get_json()["active_job"] == {
+        "job_id": accepted.get_json()["job_id"],
+        "url": accepted.headers["Location"],
+    }
+
+
+def test_get_job_returns_serializable_state_and_result():
+    executor = DeferredExecutor()
+    app = create_app(JobManager(executor=executor))
+    client = app.test_client()
+    accepted = client.post("/submit")
+    job_id = accepted.get_json()["job_id"]
+
+    assert client.get(f"/jobs/{job_id}").get_json() == {
+        "job_id": job_id,
+        "status": "in_progress",
+    }
+
+    executor.run_next()
+    assert client.get(f"/jobs/{job_id}").get_json() == {
+        "job_id": job_id,
+        "status": "success",
+        "result": {"status": "updated"},
+    }
+
+
+def test_get_unknown_job_returns_404():
+    app = create_app(JobManager(executor=DeferredExecutor()))
+
+    response = app.test_client().get("/jobs/missing")
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Job not found"
+
+
+def test_executor_submission_failure_returns_500():
+    app = create_app(JobManager(executor=RejectingExecutor()))
+
+    response = app.test_client().post("/submit")
+
+    assert response.status_code == 500
+    assert response.get_json()["message"] == "Job submission failed"

--- a/tests/api/test_job_api.py
+++ b/tests/api/test_job_api.py
@@ -17,13 +17,13 @@ def create_app(manager: JobManager) -> Flask:
     return app
 
 
-def test_submit_returns_202_with_job_id_and_location():
+def test_submit_returns_202_accepted_with_job_id_and_location():
     app = create_app(JobManager(executor=DeferredExecutor()))
 
     response = app.test_client().post("/submit")
 
     assert response.status_code == 202
-    assert response.get_json()["status"] == "success"
+    assert response.get_json()["status"] == "accepted"
     job_id = response.get_json()["job_id"]
     assert response.headers["Location"] == f"/jobs/{job_id}"
 

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -74,6 +74,25 @@ def test_unknown_job_returns_none():
     assert manager.get_job("missing") is None
 
 
+def test_get_job_dict_serializes_under_lock():
+    executor = DeferredExecutor()
+    manager = JobManager(executor=executor)
+    job = manager.run_update(lambda: {"status": "updated"})
+
+    assert manager.get_job_dict(job.job_id) == {
+        "job_id": job.job_id,
+        "status": "in_progress",
+    }
+
+    executor.run_next()
+    assert manager.get_job_dict(job.job_id) == {
+        "job_id": job.job_id,
+        "status": "success",
+        "result": {"status": "updated"},
+    }
+    assert manager.get_job_dict("missing") is None
+
+
 def test_history_is_limited_to_latest_records():
     executor = DeferredExecutor()
     manager = JobManager(max_history=2, executor=executor)

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,0 +1,135 @@
+from threading import Barrier, Lock, Thread
+from pathlib import Path
+
+import pytest
+
+from job_manager import (
+    JobConflict,
+    JobManager,
+    JobStatus,
+    JobSubmissionError,
+)
+
+
+class DeferredExecutor:
+    def __init__(self):
+        self._calls = []
+
+    def submit(self, fn, *args):
+        self._calls.append((fn, args))
+        return object()
+
+    def run_next(self):
+        fn, args = self._calls.pop(0)
+        return fn(*args)
+
+
+class RejectingExecutor:
+    def submit(self, fn, *args):
+        raise RuntimeError("executor stopped")
+
+
+def test_run_update_creates_in_progress_job_and_rejects_competitor():
+    manager = JobManager(executor=DeferredExecutor())
+
+    first = manager.run_update(lambda: {"status": "updated"})
+
+    assert first.status is JobStatus.IN_PROGRESS
+    with pytest.raises(JobConflict) as exc_info:
+        manager.run_update(lambda: {"status": "added"})
+    assert exc_info.value.active_job.job_id == first.job_id
+
+
+def test_successful_job_remains_queryable_with_its_result():
+    executor = DeferredExecutor()
+    manager = JobManager(executor=executor)
+    job = manager.run_update(lambda: {"status": "updated"})
+
+    executor.run_next()
+
+    finished = manager.get_job(job.job_id)
+    assert finished.status is JobStatus.SUCCESS
+    assert finished.result == {"status": "updated"}
+    assert finished.error is None
+
+
+def test_failed_job_remains_queryable_and_releases_active_slot():
+    executor = DeferredExecutor()
+    manager = JobManager(executor=executor)
+
+    def fail():
+        raise RuntimeError("restart failed")
+
+    job = manager.run_update(fail)
+    executor.run_next()
+
+    finished = manager.get_job(job.job_id)
+    assert finished.status is JobStatus.FAILED
+    assert finished.error == "restart failed"
+    assert manager.run_update(lambda: {}) is not None
+
+
+def test_unknown_job_returns_none():
+    manager = JobManager(executor=DeferredExecutor())
+    assert manager.get_job("missing") is None
+
+
+def test_history_is_limited_to_latest_records():
+    executor = DeferredExecutor()
+    manager = JobManager(max_history=2, executor=executor)
+    jobs = []
+    for _ in range(3):
+        jobs.append(manager.run_update(lambda: {}))
+        executor.run_next()
+
+    assert manager.get_job(jobs[0].job_id) is None
+    assert manager.get_job(jobs[1].job_id) is not None
+    assert manager.get_job(jobs[2].job_id) is not None
+
+
+def test_simultaneous_submissions_admit_exactly_one():
+    manager = JobManager(executor=DeferredExecutor())
+    barrier = Barrier(8)
+    result_lock = Lock()
+    accepted = []
+    conflicts = []
+
+    def submit():
+        barrier.wait()
+        try:
+            job = manager.run_update(lambda: {})
+        except JobConflict as exc:
+            with result_lock:
+                conflicts.append(exc.active_job.job_id)
+        else:
+            with result_lock:
+                accepted.append(job.job_id)
+
+    threads = [Thread(target=submit) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(accepted) == 1
+    assert conflicts == [accepted[0]] * 7
+
+
+def test_executor_submission_failure_is_recorded_and_slot_is_released():
+    manager = JobManager(executor=RejectingExecutor())
+
+    with pytest.raises(JobSubmissionError) as exc_info:
+        manager.run_update(lambda: {})
+
+    failed = manager.get_job(exc_info.value.job_id)
+    assert failed.status is JobStatus.FAILED
+    assert failed.error == "executor stopped"
+
+
+@pytest.mark.parametrize(
+    "dockerfile", ["package/Dockerfile", "package/Dockerfile.lite"]
+)
+def test_container_includes_job_runtime_modules(dockerfile):
+    content = Path(dockerfile).read_text(encoding="utf-8")
+    assert "COPY package/sbin/job_manager.py /" in content
+    assert "COPY package/sbin/job_api.py /" in content

--- a/tests/api/test_management_flag.py
+++ b/tests/api/test_management_flag.py
@@ -42,6 +42,11 @@ def test_metadata_splunk_disabled_returns_404():
     assert client.get("/config/metadata/splunk").status_code == 404
 
 
+def test_jobs_disabled_returns_404():
+    client = _make_client(enabled=False)
+    assert client.get("/jobs/job-1").status_code == 404
+
+
 def test_management_routes_registered_when_enabled():
     import api
     _make_client(enabled=True)
@@ -50,6 +55,7 @@ def test_management_routes_registered_when_enabled():
     assert "/config/env" in rules
     assert "/config/parsers" in rules
     assert "/config/metadata/splunk" in rules
+    assert "/jobs/<job_id>" in rules
 
 
 def test_management_routes_absent_when_disabled():
@@ -60,3 +66,4 @@ def test_management_routes_absent_when_disabled():
     assert "/config/env" not in rules
     assert "/config/parsers" not in rules
     assert "/config/metadata/splunk" not in rules
+    assert "/jobs/<job_id>" not in rules

--- a/tests/api/test_metadata_api.py
+++ b/tests/api/test_metadata_api.py
@@ -69,13 +69,14 @@ def test_get_splunk_metadata_empty_file(client, ctx_dir):
 # ---------------------------------------------------------------------------
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_set_splunk_metadata(mock_apply, client, ctx_dir):
+def test_set_splunk_metadata(mock_apply, _mock_submit, client, ctx_dir):
     entries = [{"key": "juniper_netscreen", "metadata": "index", "value": "ns_index"}]
 
     resp = client.post("/config/metadata/splunk", json={"entries": entries})
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert resp.get_json()["status"] == "metadata updated successfully"
     mock_apply.assert_called_once()
 
@@ -112,14 +113,15 @@ def test_set_splunk_metadata_no_body(client, ctx_dir):
 # ---------------------------------------------------------------------------
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_delete_metadata(mock_apply, client, ctx_dir):
+def test_delete_metadata(mock_apply, _mock_submit, client, ctx_dir):
     csv_file = ctx_dir / "splunk_metadata.csv"
     csv_file.write_text("juniper_netscreen,index,ns_index\n")
 
     resp = client.delete("/config/metadata/splunk")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "cleared successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
@@ -169,8 +171,9 @@ def test_get_compliance_no_files(client, ctx_dir):
 # ---------------------------------------------------------------------------
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_set_compliance(mock_apply, client, ctx_dir):
+def test_set_compliance(mock_apply, _mock_submit, client, ctx_dir):
     payload = {
         "conf_content": 'filter f_pci { host("pci-*" type(glob)) };',
         "csv_content": [
@@ -180,25 +183,27 @@ def test_set_compliance(mock_apply, client, ctx_dir):
 
     resp = client.post("/config/metadata/compliance", json=payload)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "compliance metadata updated successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_set_compliance_conf_only(mock_apply, client, ctx_dir):
+def test_set_compliance_conf_only(mock_apply, _mock_submit, client, ctx_dir):
     payload = {
         "conf_content": 'filter f_pci { host("pci-*" type(glob)) };',
     }
 
     resp = client.post("/config/metadata/compliance", json=payload)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     mock_apply.assert_called_once()
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_set_compliance_csv_only(mock_apply, client, ctx_dir):
+def test_set_compliance_csv_only(mock_apply, _mock_submit, client, ctx_dir):
     payload = {
         "csv_content": [
             {"filter_name": "f_pci", "field_name": ".splunk.index", "value": "pci_idx"}
@@ -207,7 +212,7 @@ def test_set_compliance_csv_only(mock_apply, client, ctx_dir):
 
     resp = client.post("/config/metadata/compliance", json=payload)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     mock_apply.assert_called_once()
 
 
@@ -269,8 +274,11 @@ def test_set_compliance_orphaned_filter(client, ctx_dir):
     assert "not defined in conf_content" in resp.get_json()["message"]
 
 
+@patch("metadata_api.submit_job", return_value=({"job_id": "job-1"}, 202))
 @patch("metadata_api.apply_with_rollback", side_effect=RuntimeError("restart failed"))
-def test_set_compliance_rollback_on_failure(mock_apply, client, ctx_dir):
+def test_set_compliance_rollback_on_failure(
+    mock_apply, mock_submit, client, ctx_dir
+):
     payload = {
         "conf_content": 'filter f_pci { host("pci-*" type(glob)) };',
         "csv_content": [
@@ -280,8 +288,9 @@ def test_set_compliance_rollback_on_failure(mock_apply, client, ctx_dir):
 
     resp = client.post("/config/metadata/compliance", json=payload)
 
-    assert resp.status_code == 500
-    assert "restart failed" in resp.get_json()["message"]
+    assert resp.status_code == 202
+    with pytest.raises(RuntimeError, match="restart failed"):
+        mock_submit.call_args.args[0]()
 
 
 # ---------------------------------------------------------------------------
@@ -289,25 +298,27 @@ def test_set_compliance_rollback_on_failure(mock_apply, client, ctx_dir):
 # ---------------------------------------------------------------------------
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_delete_compliance(mock_apply, client, ctx_dir):
+def test_delete_compliance(mock_apply, _mock_submit, client, ctx_dir):
     (ctx_dir / "compliance.conf").write_text("filter f_pci {};\n")
     (ctx_dir / "compliance.csv").write_text("f_pci,.splunk.index,pci_idx\n")
 
     resp = client.delete("/config/metadata/compliance")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert "cleared successfully" in resp.get_json()["status"]
     mock_apply.assert_called_once()
 
 
+@patch("metadata_api.submit_job", side_effect=lambda work: (work(), 202))
 @patch("metadata_api.apply_with_rollback")
-def test_delete_compliance_conf_only(mock_apply, client, ctx_dir):
+def test_delete_compliance_conf_only(mock_apply, _mock_submit, client, ctx_dir):
     (ctx_dir / "compliance.conf").write_text("filter f_pci {};\n")
 
     resp = client.delete("/config/metadata/compliance")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     mock_apply.assert_called_once()
 
 
@@ -316,3 +327,83 @@ def test_delete_compliance_no_files(client, ctx_dir):
 
     assert resp.status_code == 404
     assert "not found" in resp.get_json()["message"]
+
+
+@patch("metadata_api.submit_job", return_value=({"job_id": "job-1"}, 202))
+@patch("metadata_api.apply_with_rollback")
+def test_set_splunk_metadata_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    entries = [{"key": "juniper", "metadata": "index", "value": "network"}]
+
+    response = client.post("/config/metadata/splunk", json={"entries": entries})
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "metadata updated successfully", "entries": entries}
+    mock_apply.assert_called_once_with(
+        {ctx_dir / "splunk_metadata.csv": "juniper,index,network\r\n"}
+    )
+
+
+@patch("metadata_api.submit_job", return_value=({"job_id": "job-2"}, 202))
+@patch("metadata_api.apply_with_rollback")
+def test_delete_splunk_metadata_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    csv_file = ctx_dir / "splunk_metadata.csv"
+    csv_file.write_text("juniper,index,network\n")
+
+    response = client.delete("/config/metadata/splunk")
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "splunk_metadata.csv cleared successfully"}
+    mock_apply.assert_called_once_with({csv_file: ""})
+
+
+@patch("metadata_api.submit_job", return_value=({"job_id": "job-3"}, 202))
+@patch("metadata_api.apply_with_rollback")
+def test_set_compliance_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    payload = {
+        "conf_content": 'filter f_pci { host("pci-*") };',
+        "csv_content": [
+            {
+                "filter_name": "f_pci",
+                "field_name": ".splunk.index",
+                "value": "pci_idx",
+            }
+        ],
+    }
+
+    response = client.post("/config/metadata/compliance", json=payload)
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "compliance metadata updated successfully"}
+    mock_apply.assert_called_once_with(
+        {
+            ctx_dir / "compliance.conf": payload["conf_content"] + "\n",
+            ctx_dir / "compliance.csv": "f_pci,.splunk.index,pci_idx\r\n",
+        }
+    )
+
+
+@patch("metadata_api.submit_job", return_value=({"job_id": "job-4"}, 202))
+@patch("metadata_api.apply_with_rollback")
+def test_delete_compliance_submits_background_work(
+    mock_apply, mock_submit, client, ctx_dir
+):
+    conf_file = ctx_dir / "compliance.conf"
+    csv_file = ctx_dir / "compliance.csv"
+    conf_file.write_text("filter f_pci {};\n")
+    csv_file.write_text("f_pci,.splunk.index,pci_idx\n")
+
+    response = client.delete("/config/metadata/compliance")
+
+    assert response.status_code == 202
+    work = mock_submit.call_args.args[0]
+    assert work() == {"status": "compliance metadata cleared successfully"}
+    mock_apply.assert_called_once_with({conf_file: "", csv_file: ""})

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,127 @@
+import subprocess
+from unittest.mock import call, patch
+
+import pytest
+
+from utils import restart_syslog_ng
+
+
+def completed(args, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+@patch("utils.time.sleep")
+@patch("utils.time.monotonic", side_effect=[0, 0, 0.5, 0.5, 0.5])
+@patch("utils.subprocess.run")
+def test_restart_waits_for_healthy_replacement(mock_run, _clock, mock_sleep):
+    mock_run.side_effect = [
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pkill"]),
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pgrep"], stdout="202\n"),
+        completed(["syslog-ng-ctl"]),
+    ]
+
+    restart_syslog_ng()
+
+    assert mock_run.call_args_list == [
+        call(
+            ["pgrep", "-x", "syslog-ng"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        ),
+        call(
+            ["pkill", "syslog-ng"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ),
+        call(
+            ["pgrep", "-x", "syslog-ng"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        ),
+        call(
+            ["pgrep", "-x", "syslog-ng"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        ),
+        call(
+            ["syslog-ng-ctl", "healthcheck", "--timeout", "1"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ),
+    ]
+    mock_sleep.assert_called_once_with(0.5)
+
+
+@patch("utils.time.sleep")
+@patch("utils.time.monotonic", side_effect=[0, 0, 30])
+@patch("utils.subprocess.run")
+def test_restart_times_out_when_new_process_never_appears(
+    mock_run, _mock_monotonic, mock_sleep
+):
+    mock_run.side_effect = [
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pkill"]),
+        completed(["pgrep"], returncode=1),
+    ]
+
+    with pytest.raises(RuntimeError, match="timed out after 30 seconds"):
+        restart_syslog_ng()
+
+    mock_sleep.assert_not_called()
+
+
+@patch("utils.time.sleep")
+@patch("utils.time.monotonic", side_effect=[0, 0, 30])
+@patch("utils.subprocess.run")
+def test_restart_times_out_when_new_process_is_unhealthy(
+    mock_run, _mock_monotonic, mock_sleep
+):
+    mock_run.side_effect = [
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pkill"]),
+        completed(["pgrep"], stdout="202\n"),
+        completed(["syslog-ng-ctl"], returncode=1, stderr="not ready"),
+    ]
+
+    with pytest.raises(RuntimeError, match="timed out after 30 seconds"):
+        restart_syslog_ng()
+
+    mock_sleep.assert_not_called()
+
+
+@patch("utils.time.sleep")
+@patch("utils.time.monotonic", side_effect=[0, 0, 30])
+@patch("utils.subprocess.run")
+def test_restart_rejects_healthy_process_after_deadline(
+    mock_run, _mock_monotonic, mock_sleep
+):
+    mock_run.side_effect = [
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pkill"]),
+        completed(["pgrep"], stdout="202\n"),
+        completed(["syslog-ng-ctl"]),
+    ]
+
+    with pytest.raises(RuntimeError, match="timed out after 30 seconds"):
+        restart_syslog_ng()
+
+    mock_sleep.assert_not_called()
+
+
+@patch("utils.subprocess.run")
+def test_restart_fails_immediately_when_kill_fails(mock_run):
+    mock_run.side_effect = [
+        completed(["pgrep"], stdout="101\n"),
+        completed(["pkill"], returncode=1, stderr="no process"),
+    ]
+
+    message = "syslog-ng restart failed: no process"
+    with pytest.raises(RuntimeError, match=message):
+        restart_syslog_ng()

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from utils import restart_syslog_ng
+from utils import apply_with_rollback, restart_syslog_ng
 
 
 def completed(args, returncode=0, stdout="", stderr=""):
@@ -125,3 +125,108 @@ def test_restart_fails_immediately_when_kill_fails(mock_run):
     message = "syslog-ng restart failed: no process"
     with pytest.raises(RuntimeError, match=message):
         restart_syslog_ng()
+
+
+def test_apply_restart_failure_restores_files_and_restarts_runtime(tmp_path):
+    existing = tmp_path / "existing.conf"
+    existing.write_text("old\n", encoding="utf-8")
+    created = tmp_path / "created.conf"
+
+    with (
+        patch("utils.syntax_check"),
+        patch(
+            "utils.restart_syslog_ng",
+            side_effect=[RuntimeError("restart timed out"), None],
+        ) as mock_restart,
+        pytest.raises(RuntimeError, match="restart timed out"),
+    ):
+        apply_with_rollback(
+            {
+                existing: "new\n",
+                created: "created\n",
+            }
+        )
+
+    assert existing.read_text(encoding="utf-8") == "old\n"
+    assert not created.exists()
+    assert not existing.with_suffix(".conf.backup").exists()
+    assert not created.with_suffix(".conf.backup").exists()
+    assert mock_restart.call_count == 2
+
+
+def test_apply_reports_original_and_runtime_rollback_failures(tmp_path):
+    config = tmp_path / "parser.conf"
+    config.write_text("old\n", encoding="utf-8")
+
+    with (
+        patch("utils.syntax_check"),
+        patch(
+            "utils.restart_syslog_ng",
+            side_effect=[
+                RuntimeError("apply restart timed out"),
+                RuntimeError("rollback restart timed out"),
+            ],
+        ),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        apply_with_rollback({config: "new\n"})
+
+    assert config.read_text(encoding="utf-8") == "old\n"
+    assert str(exc_info.value) == (
+        "configuration apply failed: apply restart timed out; "
+        "rollback failed: rollback restart timed out"
+    )
+
+
+def test_syntax_failure_restores_files_without_restarting_runtime(tmp_path):
+    config = tmp_path / "parser.conf"
+    config.write_text("old\n", encoding="utf-8")
+
+    with (
+        patch("utils.syntax_check", side_effect=RuntimeError("syntax error")),
+        patch("utils.restart_syslog_ng") as mock_restart,
+        pytest.raises(RuntimeError, match="syntax error"),
+    ):
+        apply_with_rollback({config: "invalid\n"})
+
+    assert config.read_text(encoding="utf-8") == "old\n"
+    assert not config.with_suffix(".conf.backup").exists()
+    mock_restart.assert_not_called()
+
+
+def test_apply_reports_original_and_file_restore_failures(tmp_path):
+    config = tmp_path / "parser.conf"
+    config.write_text("old\n", encoding="utf-8")
+
+    with (
+        patch("utils.syntax_check"),
+        patch(
+            "utils.restart_syslog_ng",
+            side_effect=RuntimeError("apply restart timed out"),
+        ) as mock_restart,
+        patch("utils.rollback", side_effect=OSError("restore denied")),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        apply_with_rollback({config: "new\n"})
+
+    assert str(exc_info.value) == (
+        "configuration apply failed: apply restart timed out; "
+        "rollback failed: restore denied"
+    )
+    mock_restart.assert_called_once_with()
+
+
+def test_successful_apply_keeps_new_files_and_restarts_once(tmp_path):
+    config = tmp_path / "parser.conf"
+    config.write_text("old\n", encoding="utf-8")
+
+    with (
+        patch("utils.syntax_check") as mock_syntax_check,
+        patch("utils.restart_syslog_ng") as mock_restart,
+    ):
+        apply_with_rollback({config: "new\n"})
+
+    assert config.read_text(encoding="utf-8") == "new\n"
+    assert not config.with_suffix(".conf.backup").exists()
+    mock_syntax_check.assert_called_once_with()
+    mock_restart.assert_called_once_with()


### PR DESCRIPTION
Issue: Two MCP clients could modify the SC4S configuration simultaneously, potentially causing requests to be queued and updates to be lost.

Fix: Add checks to ensure that Gunicorn runs with a single thread. Convert endpoints that require a syslog-ng restart to asynchronous operations. If another job is already running, return HTTP 409.