### PR TITLE
fix: Parse high precision timestamp in new Palo Alto Network logs

### DIFF
--- a/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
+++ b/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
@@ -203,14 +203,26 @@ block parser app-syslog-pan_panos() {
                 );
             };
         } elif (message(',GLOBALPROTECT,' type(string) flags(substring))) {
-            parser {
-                csv-parser(
-                    columns("future_use1","receive_time","serial_number","log_type","future_use2","version","time_generated","vsys","event_id","stage","auth_method","tunnel_type","src_user","src_region","machine_name","public_ip","public_ipv6","private_ip","private_ipv6","host_id","serial_number","client_ver","client_os","client_os_ver","repeat_count","reason","error","opaque","status","location","login_duration","connect_method","error_code","portal","sequence_number","action_flags","event_time","selection_type","response_time","priority","attempted_gateways","gateway","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id")
-                    prefix(".values.")
-                    delimiters(',')
-                    quote-pairs('""')
-                    flags(escape-double-char)
-                );
+            if {
+                parser {
+                    csv-parser(
+                        columns("future_use1","receive_time","serial_number","log_type","future_use2","version","time_generated","vsys","event_id","stage","auth_method","tunnel_type","src_user","src_region","machine_name","public_ip","public_ipv6","private_ip","private_ipv6","host_id","serial_number","client_ver","client_os","client_os_ver","repeat_count","reason","error","opaque","status","location","login_duration","connect_method","error_code","portal","sequence_number","action_flags","high_res_time","selection_type","response_time","priority","attempted_gateways","gateway","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id")
+                        prefix(".values.")
+                        delimiters(',')
+                        quote-pairs('""')
+                        flags(escape-double-char)
+                    );
+                };
+            } elif {
+                parser {
+                    csv-parser(
+                        columns("future_use1","receive_time","serial_number","log_type","future_use2","version","time_generated","vsys","event_id","stage","auth_method","tunnel_type","src_user","src_region","machine_name","public_ip","public_ipv6","private_ip","private_ipv6","host_id","serial_number","client_ver","client_os","client_os_ver","repeat_count","reason","error","opaque","status","location","login_duration","connect_method","error_code","portal","sequence_number","action_flags","event_time","selection_type","response_time","priority","attempted_gateways","gateway","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id")
+                        prefix(".values.")
+                        delimiters(',')
+                        quote-pairs('""')
+                        flags(escape-double-char)
+                    );
+                };
             };
             rewrite {
                 r_set_splunk_dest_update_v2(
@@ -248,9 +260,38 @@ block parser app-syslog-pan_panos() {
                 );
             };
         } elif (message(',AUTH,' type(string) flags(substring))) {
+            if {
+                parser {
+                    csv-parser(
+                        columns("future_use1","receive_time","serial_number","log_type","log_subtype","version","generated_time","vsys","src_ip","user","user_normalized","object","authentication_policy","repeat_count","authentication_id","pan_vendor","log_action","server_profile","description","client_type","event_type","factor_number","sequence_number","action_flags","device_group_hierarchy_1","device_group_hierarchy_2","device_group_hierarchy_3","device_group_hierarchy_4","vsys_name","dvc_name","vsys_id","authentication_protocol","rule","high_res_time","src_host_category","src_host_profile","src_host_model","src_host_vendor","src_host_os_name","src_host_os_version","src_host","src_mac","region","future_use2","user_agent","session_id","cluster_name")
+                        prefix(".values.")
+                        delimiters(',')
+                        quote-pairs('""')
+                        flags(escape-double-char)
+                    );
+                };
+            } elif {
+                parser {
+                    csv-parser(
+                        columns("future_use1","receive_time","serial_number","log_type","log_subtype","version","generated_time","vsys","src_ip","user","user_normalized","object","authentication_policy","repeast_count","authentication_id","pan_vendor","log_action","server_profile","description","client_type","event_type","factor_number","sequence_number","action_flags","device_group_hierarchy_1","device_group_hierarchy_2","device_group_hierarchy_3","device_group_hierarchy_4","vsys","dvc_name","vsys_id","authentication_protocol","rule","timestamp","src_host_category","src_host_profile","src_host_model","src_host_vendor","src_host_os_name","src_host_os_version","src_host","src_mac","region","future_use2","user_agent","session_id","cluster_name")
+                        prefix(".values.")
+                        delimiters(',')
+                        quote-pairs('""')
+                        flags(escape-double-char)
+                    );
+                };
+            };
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    index('netauth')
+                    class('authentication')
+                    sourcetype('pan:auth')
+                );
+            };
+        } elif (message(',SCTP,' type(string) flags(substring))) {
             parser {
                 csv-parser(
-                    columns("future_use1","receive_time","serial_number","log_type","log_subtype","version","generated_time","vsys","src_ip","user","user_normalized","object","authentication_policy","repeast_count","authentication_id","pan_vendor","log_action","server_profile","description","client_type","event_type","factor_number","sequence_number","action_flags","device_group_hierarchy_1","device_group_hierarchy_2","device_group_hierarchy_3","device_group_hierarchy_4","vsys","dvc_name","vsys_id","authentication_protocol","rule","timestamp","src_host_category","src_host_profile","src_host_model","src_host_vendor","src_host_os_name","src_host_os_version","src_host","src_mac","region","future_use2","user_agent","session_id","cluster_name")
+                    columns("future_use1","receive_time","serial_number","type","future_use2","future_use3","generated_time","src_ip","dest_ip","future_use4","future_use5","rule","future_use6","future_use7","future_use8","vsys","src_zone","dest_zone","inbound_interface","outbound_interface","log_action","future_use9","session_id","repeat_count","src_port","dest_port","future_use10","future_use11","future_use12","future_use13","ip_protocol","action","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","sequence_number","future_use14","sctp_assoc_id","payload_proto_id","severity","sctp_chunk_type","future_use15","sctp_verification_tag1","sctp_verification_tag2","sctp_cause_code","diameter_app_id","diameter_command_code","diameter_avp_code","sctp_stream_id","sctp_assoc_end_reason","op_code","sccp_calling_party_ssn","sccp_calling_party_gt","sctp_filter","sctp_chunks","sctp_chunks_sent","sctp_chunks_received","packets","packets_sent","packets_received","rule_uuid","high_res_time")
                     prefix(".values.")
                     delimiters(',')
                     quote-pairs('""')
@@ -259,9 +300,43 @@ block parser app-syslog-pan_panos() {
             };
             rewrite {
                 r_set_splunk_dest_update_v2(
-                    index('netauth')
-                    class('authentication')
-                    sourcetype('pan:auth')
+                    index('netfw')
+                    class('sctp')
+                    sourcetype('pan:sctp')
+                );
+            };
+        } elif (message(',GTP,' type(string) flags(substring))) {
+            parser {
+                csv-parser(
+                    columns("future_use1","receive_time","serial_number","type","threat_content_type","future_use2","generated_time","src_ip","dest_ip","future_use3","future_use4","rule","future_use5","future_use6","app","vsys","src_zone","dest_zone","inbound_interface","outbound_interface","log_action","future_use7","session_id","future_use8","src_port","dest_port","future_use9","future_use10","future_use11","protocol","action","gtp_event_type","msisdn","access_point_name","radio_access_technology","gtp_message_type","end_user_ip","teid1","teid2","gtp_interface","gtp_cause","severity","serving_mcc","serving_mnc","area_code","cell_id","gtp_event_code","future_use12","future_use13","src_location","dest_location","future_use14","future_use15","future_use16","future_use17","future_use18","future_use19","future_use20","tunnel_id_imsi","monitor_tag_imei","future_use21","future_use22","future_use23","future_use24","future_use25","future_use26","future_use27","future_use28","future_use29","future_use30","future_use31","future_use32","future_use33","future_use34","future_use35","future_use36","start_time","elapsed_time","tunnel_inspection_rule","remote_user_ip","remote_user_id","rule_uuid","pcap_id","high_res_time","a_slice_service_type","a_slice_differentiator","app_subcategory","app_category","app_technology","app_risk","app_characteristic","app_container","app_saas","app_sanctioned_state")
+                    prefix(".values.")
+                    delimiters(',')
+                    quote-pairs('""')
+                    flags(escape-double-char)
+                );
+            };
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    index('netfw')
+                    class('gtp')
+                    sourcetype('pan:gtp')
+                );
+            };
+        } elif (message(',TUNNEL,' type(string) flags(substring))) {
+            parser {
+                csv-parser(
+                    columns("future_use1","receive_time","serial_number","type","subtype","future_use2","generated_time","src_ip","dest_ip","nat_src_ip","nat_dest_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","inbound_interface","outbound_interface","log_action","future_use3","session_id","repeat_count","src_port","dest_port","nat_src_port","nat_dest_port","flags","protocol","action","severity","sequence_number","action_flags","src_location","dest_location","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","tunnel_id_imsi","monitor_tag_imei","parent_session_id","parent_start_time","tunnel","bytes","bytes_sent","bytes_received","packets","packets_sent","packets_received","max_encapsulation","unknown_protocol","strict_check","tunnel_fragment","sessions_created","sessions_closed","session_end_reason","action_source","start_time","elapsed_time","tunnel_inspection_rule","remote_user_ip","remote_user_id","rule_uuid","pcap_id","dyn_user_group_name","src_edl","dest_edl","high_res_time","a_slice_differentiator","a_slice_service_type","pdu_session_id","app_subcategory","app_category","app_technology","app_risk","app_characteristic","app_container","app_saas","app_sanctioned_state","cluster_name")
+                    prefix(".values.")
+                    delimiters(',')
+                    quote-pairs('""')
+                    flags(escape-double-char)
+                );
+            };
+            rewrite {
+                r_set_splunk_dest_update_v2(
+                    index('netfw')
+                    class('tunnel')
+                    sourcetype('pan:tunnel')
                 );
             };
         } else { };

--- a/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
+++ b/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
@@ -273,7 +273,7 @@ block parser app-syslog-pan_panos() {
             } elif {
                 parser {
                     csv-parser(
-                        columns("future_use1","receive_time","serial_number","log_type","log_subtype","version","generated_time","vsys","src_ip","user","user_normalized","object","authentication_policy","repeast_count","authentication_id","pan_vendor","log_action","server_profile","description","client_type","event_type","factor_number","sequence_number","action_flags","device_group_hierarchy_1","device_group_hierarchy_2","device_group_hierarchy_3","device_group_hierarchy_4","vsys","dvc_name","vsys_id","authentication_protocol","rule","timestamp","src_host_category","src_host_profile","src_host_model","src_host_vendor","src_host_os_name","src_host_os_version","src_host","src_mac","region","future_use2","user_agent","session_id","cluster_name")
+                        columns("future_use1","receive_time","serial_number","log_type","log_subtype","version","generated_time","vsys","src_ip","user","user_normalized","object","authentication_policy","repeat_count","authentication_id","pan_vendor","log_action","server_profile","description","client_type","event_type","factor_number","sequence_number","action_flags","device_group_hierarchy_1","device_group_hierarchy_2","device_group_hierarchy_3","device_group_hierarchy_4","vsys_name","dvc_name","vsys_id","authentication_protocol","rule","timestamp","src_host_category","src_host_profile","src_host_model","src_host_vendor","src_host_os_name","src_host_os_version","src_host","src_mac","region","future_use2","user_agent","session_id","cluster_name")
                         prefix(".values.")
                         delimiters(',')
                         quote-pairs('""')
@@ -345,6 +345,12 @@ block parser app-syslog-pan_panos() {
         # constituent parts.  LEGACY_MSGHDR is null in IETF so concatenation is a no-op (so no test is needed).
 
         # Parse the date
+        # PAN-OS 9.1 and earlier sets high_res_time to epoch (1969-12-31); clear it so date-parser falls back to generated_time.
+        rewrite {
+            set("" value(".values.high_res_time")
+                condition(match('1969' value('.values.high_res_time') type(string) flags(prefix)))
+            );
+        };
         if {
             parser {
                 # Try to parse the high-resolution timestamp first
@@ -363,6 +369,16 @@ block parser app-syslog-pan_panos() {
                         '%Y/%m/%d %H:%M:%S',
                         '%Y-%m-%dT%H:%M:%S.%f%z',)
                         template("${.values.generated_time}")
+                );
+            };
+        } elif {
+            parser {
+                # Fallback for GLOBALPROTECT log type which uses time_generated
+                date-parser-nofilter(format(
+                        '%Y/%m/%d %H:%M:%S.%f',
+                        '%Y/%m/%d %H:%M:%S',
+                        '%Y-%m-%dT%H:%M:%S.%f%z',)
+                        template("${.values.time_generated}")
                 );
             };
         };

--- a/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
+++ b/package/shared/addons/palo-alto/app-syslog-pan_panos.conf
@@ -362,9 +362,9 @@ block parser app-syslog-pan_panos() {
             };
         } elif {
             parser {
-                # Fallback for backward compatibility
+                # Fallback to log types (generated_time)
                 # 2012/04/10 04:39:55
-                date-parser-nofilter(format(
+                date-parser(format(
                         '%Y/%m/%d %H:%M:%S.%f',
                         '%Y/%m/%d %H:%M:%S',
                         '%Y-%m-%dT%H:%M:%S.%f%z',)
@@ -373,7 +373,7 @@ block parser app-syslog-pan_panos() {
             };
         } elif {
             parser {
-                # Fallback for GLOBALPROTECT log type which uses time_generated
+                # Fallback for GLOBALPROTECT which uses time_generated instead of generated_time
                 date-parser-nofilter(format(
                         '%Y/%m/%d %H:%M:%S.%f',
                         '%Y/%m/%d %H:%M:%S',

--- a/tests/test_palo_alto.py
+++ b/tests/test_palo_alto.py
@@ -36,53 +36,580 @@ def get_panlc_times():
     epoch = f"{epoch_ms // 1000}.{epoch_ms % 1000:03d}"
     return bsd, time, orig_timestamp_str, epoch
 
-# <190>Jan 28 01:28:35 PA-VM300-goran1 1,2014/01/28 01:28:35,007200001056,TRAFFIC,end,1,2014/01/28 01:28:34,192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,netbios-ns,vsys1,Trust,Untrust,ethernet1/1,ethernet1/2,To-Panorama,2014/01/28 01:28:34,8720,1,137,137,11637,137,0x400000,udp,allow,276,276,0,3,2014/01/28 01:28:02,2,any,0,2076326,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,3,0
+# # <190>Jan 28 01:28:35 PA-VM300-goran1 1,2014/01/28 01:28:35,007200001056,TRAFFIC,end,1,2014/01/28 01:28:34,192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,netbios-ns,vsys1,Trust,Untrust,ethernet1/1,ethernet1/2,To-Panorama,2014/01/28 01:28:34,8720,1,137,137,11637,137,0x400000,udp,allow,276,276,0,3,2014/01/28 01:28:02,2,any,0,2076326,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,3,0
+# @mark.addons("paloalto")
+# def test_palo_alto_traffic(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:34:14,000000000000,TRAFFIC,end,0000,2025/03/28 05:34:14,11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,2025/03/28 05:34:14,1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,XX-XX-XXX-XX-000X,from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2025-03-28T05:34:15.104-04:00,,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0
+# @mark.addons("paloalto")
+# def test_palo_alto_traffic_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TRAFFIC,end,0000,{{ time }},11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,{{ time }},1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,{{ high_res_time }},,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0
+# @mark.addons("paloalto")
+# def test_palo_alto_traffic_dvc_name(
+#     record_property,  setup_splunk, setup_sc4s
+# ):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }}-no 1,{{ time }},007200C01056,TRAFFIC,start,1,{{ time }},192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,{{ time }},11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0,unknown,dg1,dg2,dg3,dg4,vsys_n13,{{ host }},action_source,src_vm,dest_vm,tunnel_id,tunnel_monitor_tag,tunnel_session_id,tunnel_start_time,tunnel_type\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Mar 14 14:28:52 host-name 1,2025/03/14 16:28:52,111111111111111,CONFIG,0,1111,2025/03/14 16:28:40,0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,host-name,0,,0,2025-03-14T16:28:40.583+01:00
+# @mark.addons("paloalto")
+# def test_palo_alto_config_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111,CONFIG,0,1111,{{ time }},0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,{{ host }},0,,0,{{ high_res_time }}\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:config"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Oct 30 09:46:17 1,2012/10/30 09:46:17,01606001116,THREAT,url,1,2012/04/10 04:39:55,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,22860,1,59303,80,0,0,0x208000,tcp,alert,"litetopdetect.cn/index.php",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html
+# @mark.addons("paloalto")
+# def test_palo_alto_threat_old_format(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# # <190>Jan 28 01:28:35 fooooo 1,2020/07/08 16:48:50,013201020735,THREAT,url,2049,2020/07/08 16:48:48,10.1.1.1,1.1.1.2,1.1.1.1,1.1.1.3,URLFilter_CatchAll_Internet,testuser,,arcgis,vsys1,DMZ,Outside,ae3,ae1,Panorama-Only,2020/07/08 16:48:48,357728,1,61066,80,33396,80,0x8403000,tcp,alert,"geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?distance=100&f=json&location={""x"":-33,""y"":22.3,""spatialReference"":{""wkid"":111}}",(9999),ALL-WhitelistedURLs,informational,client-to-server,6816029286804555581,0xa000000000000000,Internal,United States,0,application/json,0,,,1,,,,,,,,0,11,16,0,0,,TESTFW01,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,
+# @mark.addons("paloalto")
+# def test_palo_alto_threat_old_format_2(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Apr 02 11:57:03 fooooo 1,2025/04/02 11:57:03,000000000000,THREAT,url,2562,2025/04/02 11:57:03,11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,2025/04/02 11:57:03,111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,XX-XX-XXX-XX-111X,,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2025-04-02T11:57:03.887-04:00,,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,
+# @mark.addons("paloalto")
+# def test_palo_alto_threat_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     """
+#     If the high-resolution timestamp is available, it should be used instead of the regular timestamp.
+#     """
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ recv_time }},00000000000,THREAT,url,2562,{{ recv_time }},11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,{{ recv_time }},111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}\}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,{{ host }},,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,{{ high_res_time }},,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,\n',
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, recv_time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <14>1 2020-10-09T18:39:02-04:00 paloietf.com - - - - 1,2020/10/09 17:43:54,007200001056,TRAFFIC,end,1210,2020/10/09 17:43:54,10.10.30.69,13.249.117.12,12.235.174.210,13.249.117.12,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,dvc_name,from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0
+# @mark.addons("paloalto")
+# def test_palo_alto_traffic_5424(
+#     record_property,  setup_splunk, setup_sc4s
+# ):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     iso, _, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         "{{ mark }}1 {{ iso }} {{ host }} - - - - 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+#     )
+#     message = mt.render(mark="<14>", iso=iso, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# @mark.addons("paloalto")
+# def test_palo_alto_traffic_mstime(
+#     record_property,  setup_splunk, setup_sc4s
+# ):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+#     epoch = epoch[:-3]
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# # <14>May 11 10:13:22 xxxxxx 1,2020/05/11 10:13:22,015451000001111,HIPMATCH,0,2049,2020/05/11 10:13:22,xx.xx,vsys1,xx-xxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,xxxxx,1,0.0.0.0,
+# @mark.addons("paloalto")
+# def test_palo_alto_hipmatch(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+#     epoch = epoch[:-3]
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},015451000001111,HIPMATCH,0,2049,{{ time }},xxxx.xxx,vsys1,xx-xxxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,{{ host }},1,0.0.0.0,\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Mar 28 05:40:45 system-host 1,2025/04/02 17:55:34,1111111111111111111,HIPMATCH,0,1111,2025/04/02 17:55:28,user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,XXXXXXXXXXXX,1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,2025-04-02T17:55:28.942+02:00
+# @mark.addons("paloalto")
+# def test_palo_alto_hipmatch_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},1111111111111111111,HIPMATCH,0,1111,{{ time }},user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,{{ host }},1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,{{ high_res_time }}\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# @mark.addons("paloalto")
+# def test_palo_alto_globalprotect(
+#     record_property,  setup_splunk, setup_sc4s
+# ):
+#     get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     orig_host = get_host_name()
+#     overwritten_host_name = get_host_name()
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,2023-11-09T16:39:17.223+01:00,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
+#         + "\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netfw host={{ overwritten_host_name }} sourcetype="pan:globalprotect"'
+#     )
+#     search = st.render(epoch=epoch, overwritten_host_name=overwritten_host_name)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", overwritten_host_name)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# # <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
+# @mark.addons("paloalto")
+# def test_palo_alto_system(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }}'
+#         + "\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <14>1 2026-03-18T08:30:10+01:00 testpanorama01.customer.com - - - - 1,2026/03/18 08:30:10,000702196763,SYSTEM,monitoring,0,2026/03/18 08:30:10,,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,testpanorama01,0,0,2026-03-18T08:30:10.000+01:00
+# @mark.addons("paloalto")
+# def test_palo_alto_system_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000702196763,SYSTEM,monitoring,0,{{ time }},,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,{{ host }},0,0,{{ high_res_time }}\n'
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,device-name,1,,2025/03/28 05:40:45,1,0x0,a111111,,2025-03-28T05:40:45.986-04:00
+# @mark.addons("paloalto")
+# def test_palo_alto_userid_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,{{ host }},1,,2025/03/28 05:40:45,1,0x0,a111111,,{{ high_res_time }}\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:userid"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
+# @mark.addons("paloalto")
+# def test_palo_alto_system_futureproof(
+#     record_property,  setup_splunk, setup_sc4s
+# ):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }},something'
+#         + "\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# # <14>1 2023-07-06T19:20:22+00:00 DEVICE_NAME 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no
+# @mark.addons("paloalto")
+# def test_palo_alto_decryption(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+#     dt = datetime.datetime.now(datetime.timezone.utc)
+#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+#     # Tune time functions
+#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
+#     epoch = epoch[:-7]
+
+#     mt = env.from_string(
+#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no\n'
+#     )
+#     message = mt.render(mark="<14>", bsd=bsd, host=host, time=time)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+# # <190>Mar 28 05:40:45 system-host 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,2025-04-02T15:56:19.287+00:00,,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,ssl,no,no
+# @mark.addons("paloalto")
+# def test_palo_alto_decryption_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+#     mt = env.from_string(
+#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,{{ high_res_time }},,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no\n"
+#     )
+#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+#     st = env.from_string(
+#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
+#     )
+#     search = st.render(epoch=epoch, host=host)
+
+#     result_count, _ = splunk_single(setup_splunk, search)
+
+#     record_property("host", host)
+#     record_property("resultCount", result_count)
+#     record_property("message", message)
+
+#     assert result_count == 1
+
+
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,GLOBALPROTECT,0,2561,2025/03/28 05:40:45,vsys1,gateway-logout,logout,,,USERNAME,XX,MACHINENAME,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,HOSTID,SERIAL,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,PORTALNAME,GATEWAY,0x8000000000000000,2025-03-28T05:40:45.986-04:00,,,,,,13,19,52,450,,system-host,1
 @mark.addons("paloalto")
-def test_palo_alto_traffic(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:34:14,000000000000,TRAFFIC,end,0000,2025/03/28 05:34:14,11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,2025/03/28 05:34:14,1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,XX-XX-XXX-XX-000X,from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2025-03-28T05:34:15.104-04:00,,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0
-@mark.addons("paloalto")
-def test_palo_alto_traffic_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+def test_palo_alto_globalprotect_high_resolution_timestamp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
     mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TRAFFIC,end,0000,{{ time }},11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,{{ time }},1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,{{ high_res_time }},,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0\n"
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,USERNAME,XX,MACHINENAME,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,HOSTID,SERIAL,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,PORTALNAME,{{ host }},0x8000000000000000,{{ high_res_time }},,,,,,13,19,52,450,,{{ host }},1\n'
     )
     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:globalprotect"'
     )
     search = st.render(epoch=epoch, host=host)
 
@@ -94,87 +621,22 @@ def test_palo_alto_traffic_high_resolution_timestamp(record_property,  setup_spl
 
     assert result_count == 1
 
-# Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0
+
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,AUTH,0,2562,2025/03/28 05:40:45,vsys1,10.0.0.1,user,,object,auth-policy,1,1111,Palo Alto Networks,log-action,server-profile,description,sso,logout,1,1111111,0x0,0,0,0,0,vsys1,system-host,1,kerberos,rule1,2025-03-28T05:40:45.986-04:00,host-cat,host-profile,host-model,host-vendor,Windows,10,hostname,aa:bb:cc:dd:ee:ff,US,,Mozilla,1111,cluster
 @mark.addons("paloalto")
-def test_palo_alto_traffic_dvc_name(
-    record_property,  setup_splunk, setup_sc4s
-):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }}-no 1,{{ time }},007200C01056,TRAFFIC,start,1,{{ time }},192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,{{ time }},11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0,unknown,dg1,dg2,dg3,dg4,vsys_n13,{{ host }},action_source,src_vm,dest_vm,tunnel_id,tunnel_monitor_tag,tunnel_session_id,tunnel_start_time,tunnel_type\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Mar 14 14:28:52 host-name 1,2025/03/14 16:28:52,111111111111111,CONFIG,0,1111,2025/03/14 16:28:40,0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,host-name,0,,0,2025-03-14T16:28:40.583+01:00
-@mark.addons("paloalto")
-def test_palo_alto_config_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+def test_palo_alto_auth_high_resolution_timestamp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
     mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111,CONFIG,0,1111,{{ time }},0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,{{ host }},0,,0,{{ high_res_time }}\n"
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,AUTH,0,2562,{{ time }},vsys1,10.0.0.1,user,,object,auth-policy,1,1111,Palo Alto Networks,log-action,server-profile,description,sso,logout,1,1111111,0x0,0,0,0,0,vsys1,{{ host }},1,kerberos,rule1,{{ high_res_time }},host-cat,host-profile,host-model,host-vendor,Windows,10,hostname,aa:bb:cc:dd:ee:ff,US,,Mozilla,1111,cluster\n"
     )
     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:config"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Oct 30 09:46:17 1,2012/10/30 09:46:17,01606001116,THREAT,url,1,2012/04/10 04:39:55,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,22860,1,59303,80,0,0,0x208000,tcp,alert,"litetopdetect.cn/index.php",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html
-@mark.addons("paloalto")
-def test_palo_alto_threat_old_format(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+        'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:auth"'
     )
     search = st.render(epoch=epoch, host=host)
 
@@ -187,92 +649,28 @@ def test_palo_alto_threat_old_format(record_property,  setup_splunk, setup_sc4s)
     assert result_count == 1
 
 
-# <190>Jan 28 01:28:35 fooooo 1,2020/07/08 16:48:50,013201020735,THREAT,url,2049,2020/07/08 16:48:48,10.1.1.1,1.1.1.2,1.1.1.1,1.1.1.3,URLFilter_CatchAll_Internet,testuser,,arcgis,vsys1,DMZ,Outside,ae3,ae1,Panorama-Only,2020/07/08 16:48:48,357728,1,61066,80,33396,80,0x8403000,tcp,alert,"geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?distance=100&f=json&location={""x"":-33,""y"":22.3,""spatialReference"":{""wkid"":111}}",(9999),ALL-WhitelistedURLs,informational,client-to-server,6816029286804555581,0xa000000000000000,Internal,United States,0,application/json,0,,,1,,,,,,,,0,11,16,0,0,,TESTFW01,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,SCTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,,,,,,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,1,1111,2905,,,,sctp,allow,0,0,0,0,vsys1,system-host,1111111,,,1111111,,2,sctp-data,sctp-init,tag1,tag2,,,,,,,,,,,,,,,,,,0,0,0,rule-uuid,2025-03-28T05:40:45.986-04:00
 @mark.addons("paloalto")
-def test_palo_alto_threat_old_format_2(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Apr 02 11:57:03 fooooo 1,2025/04/02 11:57:03,000000000000,THREAT,url,2562,2025/04/02 11:57:03,11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,2025/04/02 11:57:03,111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,XX-XX-XXX-XX-111X,,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2025-04-02T11:57:03.887-04:00,,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,
-@mark.addons("paloalto")
-def test_palo_alto_threat_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-    """
-    If the high-resolution timestamp is available, it should be used instead of the regular timestamp.
-    """
+def test_palo_alto_sctp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
     mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ recv_time }},00000000000,THREAT,url,2562,{{ recv_time }},11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,{{ recv_time }},111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}\}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,{{ host }},,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,{{ high_res_time }},,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,\n',
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,SCTP,0,,{{ time }},10.0.0.1,10.0.0.2,,,,,,,,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1111,1,11111,2905,,,,sctp,allow,0,0,0,0,vsys1,{{ host }},1111111,,12345,0,medium,data,,,0x12345678,0x87654321,0,0,0,0,0,0,0,0,0,10,5,5,50,25,25,rule-uuid,{{ high_res_time }}\n"
     )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, recv_time=time, high_res_time=orig_timestamp_str)
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+    print("time string: ", time)
+    print("epoch time: ", epoch)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:sctp"'
     )
     search = st.render(epoch=epoch, host=host)
 
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <14>1 2020-10-09T18:39:02-04:00 paloietf.com - - - - 1,2020/10/09 17:43:54,007200001056,TRAFFIC,end,1210,2020/10/09 17:43:54,10.10.30.69,13.249.117.12,12.235.174.210,13.249.117.12,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,dvc_name,from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0
-@mark.addons("paloalto")
-def test_palo_alto_traffic_5424(
-    record_property,  setup_splunk, setup_sc4s
-):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    iso, _, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        "{{ mark }}1 {{ iso }} {{ host }} - - - - 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-    )
-    message = mt.render(mark="<14>", iso=iso, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-    )
-    search = st.render(epoch=epoch, host=host)
+    print("search string: ", search)
 
     result_count, _ = splunk_single(setup_splunk, search)
 
@@ -283,306 +681,52 @@ def test_palo_alto_traffic_5424(
     assert result_count == 1
 
 
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,GTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,rule1,,,web-browsing,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,,1111,2152,,,,,tcp,allow,gtp-create-session,441234567890,internet.apn,lte,create-session-request,192.168.1.1,teid1,teid2,s11,0,medium,310,260,111,22222,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,60,3600,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,2025-03-28T05:40:45.986-04:00,,,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no
 @mark.addons("paloalto")
-def test_palo_alto_traffic_mstime(
-    record_property,  setup_splunk, setup_sc4s
-):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-    epoch = epoch[:-3]
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-
-# <14>May 11 10:13:22 xxxxxx 1,2020/05/11 10:13:22,015451000001111,HIPMATCH,0,2049,2020/05/11 10:13:22,xx.xx,vsys1,xx-xxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,xxxxx,1,0.0.0.0,
-@mark.addons("paloalto")
-def test_palo_alto_hipmatch(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-    epoch = epoch[:-3]
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},015451000001111,HIPMATCH,0,2049,{{ time }},xxxx.xxx,vsys1,xx-xxxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,{{ host }},1,0.0.0.0,\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Mar 28 05:40:45 system-host 1,2025/04/02 17:55:34,1111111111111111111,HIPMATCH,0,1111,2025/04/02 17:55:28,user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,XXXXXXXXXXXX,1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,2025-04-02T17:55:28.942+02:00
-@mark.addons("paloalto")
-def test_palo_alto_hipmatch_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+def test_palo_alto_gtp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
     mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},1111111111111111111,HIPMATCH,0,1111,{{ time }},user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,{{ host }},1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,{{ high_res_time }}\n"
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,GTP,0,,{{ time }},10.0.0.1,10.0.0.2,,,rule1,,,web-browsing,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1111,,11111,2152,,,,tcp,allow,gtp-create-session,441234567890,internet.apn,lte,create-session-request,192.168.1.1,teid1,teid2,s11,0,medium,310,260,12345,67890,1,,,10.0.0.0-10.255.255.255,United States,,,,,,,,0,0,,,,,,,,,,,,,,,,,2025/03/28 05:39:45,3600,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,{{ high_res_time }},,,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    print("time string: ", time)
+    print("epoch time: ", epoch)
+
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:gtp"'
+    )
+    search = st.render(epoch=epoch, host=host)
+
+    print("search string: ", search)
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,TUNNEL,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,10.0.0.1,10.0.0.2,rule1,user,,ssl,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,1,1111,443,0,0,0x0,tcp,allow,medium,1111111,0x0,US,US,0,0,0,0,vsys1,system-host,,,,,gre,1024,512,512,10,5,5,0,0,0,0,5,3,tcp-fin,from-policy,2025/03/28 05:39:45,60,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,dyn-group,,,2025-03-28T05:40:45.986-04:00,,,pdu-session-id,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no,cluster
+@mark.addons("paloalto")
+def test_palo_alto_tunnel(record_property, setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TUNNEL,0,,{{ time }},10.0.0.1,10.0.0.2,10.0.0.1,10.0.0.2,rule1,user,,ssl,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,1,1111,443,0,0,0x0,tcp,allow,medium,1111111,0x0,US,US,0,0,0,0,vsys1,{{ host }},,,,,gre,1024,512,512,10,5,5,0,0,0,0,5,3,tcp-fin,from-policy,2025/03/28 05:39:45,60,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,dyn-group,,,{{ high_res_time }},,,pdu-session-id,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no,cluster\n"
     )
     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
     st = env.from_string(
-        'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-@mark.addons("paloalto")
-def test_palo_alto_globalprotect(
-    record_property,  setup_splunk, setup_sc4s
-):
-    get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-    orig_host = get_host_name()
-    overwritten_host_name = get_host_name()
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,2023-11-09T16:39:17.223+01:00,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
-        + "\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netfw host={{ overwritten_host_name }} sourcetype="pan:globalprotect"'
-    )
-    search = st.render(epoch=epoch, overwritten_host_name=overwritten_host_name)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", overwritten_host_name)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-
-# <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
-@mark.addons("paloalto")
-def test_palo_alto_system(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }}'
-        + "\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <14>1 2026-03-18T08:30:10+01:00 testpanorama01.customer.com - - - - 1,2026/03/18 08:30:10,000702196763,SYSTEM,monitoring,0,2026/03/18 08:30:10,,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,testpanorama01,0,0,2026-03-18T08:30:10.000+01:00
-@mark.addons("paloalto")
-def test_palo_alto_system_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000702196763,SYSTEM,monitoring,0,{{ time }},,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,{{ host }},0,0,{{ high_res_time }}\n'
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,device-name,1,,2025/03/28 05:40:45,1,0x0,a111111,,2025-03-28T05:40:45.986-04:00
-@mark.addons("paloalto")
-def test_palo_alto_userid_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,{{ host }},1,,2025/03/28 05:40:45,1,0x0,a111111,,{{ high_res_time }}\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:userid"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
-@mark.addons("paloalto")
-def test_palo_alto_system_futureproof(
-    record_property,  setup_splunk, setup_sc4s
-):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }},something'
-        + "\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-
-# <14>1 2023-07-06T19:20:22+00:00 DEVICE_NAME 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no
-@mark.addons("paloalto")
-def test_palo_alto_decryption(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
-    epoch = epoch[:-7]
-
-    mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no\n'
-    )
-    message = mt.render(mark="<14>", bsd=bsd, host=host, time=time)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
-    )
-    search = st.render(epoch=epoch, host=host)
-
-    result_count, _ = splunk_single(setup_splunk, search)
-
-    record_property("host", host)
-    record_property("resultCount", result_count)
-    record_property("message", message)
-
-    assert result_count == 1
-
-# <190>Mar 28 05:40:45 system-host 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,2025-04-02T15:56:19.287+00:00,,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,ssl,no,no
-@mark.addons("paloalto")
-def test_palo_alto_decryption_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
-
-    mt = env.from_string(
-        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,{{ high_res_time }},,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no\n"
-    )
-    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
-
-    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
-
-    st = env.from_string(
-        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:tunnel"'
     )
     search = st.render(epoch=epoch, host=host)
 

--- a/tests/test_palo_alto.py
+++ b/tests/test_palo_alto.py
@@ -409,6 +409,110 @@ def test_palo_alto_globalprotect(
     assert result_count == 1
 
 
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,2025/03/28 05:40:45,vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,system-host,0x8000000000000000,,,,,,,13,19,52,450,,system-host,1
+@mark.addons("paloalto")
+def test_palo_alto_globalprotect_old_format(
+    record_property, setup_splunk, setup_sc4s
+):
+    """Verify old-format GLOBALPROTECT logs (no high_res_time) fall back to time_generated."""
+    get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    orig_host = get_host_name()
+    overwritten_host_name = get_host_name()
+
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
+
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
+        + "\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host={{ overwritten_host_name }} sourcetype="pan:globalprotect"'
+    )
+    search = st.render(epoch=epoch, overwritten_host_name=overwritten_host_name)
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("host", overwritten_host_name)
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,AUTH,0,2562,2025/03/28 05:40:45,vsys1,10.0.0.1,user,,object,auth-policy,1,12345,Palo Alto Networks,log-action,ldap-server,description,sso,authentication,1,1234567890123456789,0x8000000000000000,0,0,0,0,vsys1,system-host,1,kerberos,rule1,,,,,,Windows,10,hostname,aa:bb:cc:dd:ee:ff,US,,Mozilla/5.0,1234567,
+@mark.addons("paloalto")
+def test_palo_alto_auth_old_format(record_property, setup_splunk, setup_sc4s):
+    """Verify old-format AUTH logs (no high_res_time) fall back to generated_time."""
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
+
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,AUTH,0,2562,{{ time }},vsys1,10.0.0.1,user,,object,auth-policy,1,12345,Palo Alto Networks,log-action,ldap-server,description,sso,authentication,1,1234567890123456789,0x8000000000000000,0,0,0,0,vsys1,{{ host }},1,kerberos,rule1,,,,,,Windows,10,hostname,aa:bb:cc:dd:ee:ff,US,,Mozilla/5.0,1234567,\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:auth"'
+    )
+    search = st.render(epoch=epoch, host=host)
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,TRAFFIC,end,,2025/03/28 05:40:45,10.0.0.1,203.0.113.10,10.0.0.1,203.0.113.10,rule1,,,ssl,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1234567,1,54321,443,54321,443,0x400000,tcp,allow,12345,6789,5556,50,2025/03/28 05:40:45,30,general-internet,,1234567890123456789,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,25,25,tcp-fin,0,0,0,0,vsys1,system-host,from-policy,,,0,0,0,0,N/A,0,0,0,0,rule-uuid,0,0,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1969-12-31T16:00:00.000-08:00,,,management,general-internet,client-server,1,has-known-vulnerability,,,no,no,no
+@mark.addons("paloalto")
+def test_palo_alto_pan_os_91_high_res_time(record_property, setup_splunk, setup_sc4s):
+    """Verify PAN-OS 9.1 high_res_time (1969-12-31) is ignored and generated_time is used instead."""
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
+
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
+
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TRAFFIC,end,,{{ time }},10.0.0.1,203.0.113.10,10.0.0.1,203.0.113.10,rule1,,,ssl,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1234567,1,54321,443,54321,443,0x400000,tcp,allow,12345,6789,5556,50,{{ time }},30,general-internet,,1234567890123456789,0x8000000000000000,10.0.0.0-10.255.255.255,United States,,25,25,tcp-fin,0,0,0,0,vsys1,{{ host }},from-policy,,,0,0,0,0,N/A,0,0,0,0,rule-uuid,0,0,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1969-12-31T16:00:00.000-08:00,,,management,general-internet,client-server,1,has-known-vulnerability,,,no,no,no\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
+
+    result_count, _ = splunk_single(setup_splunk, search)
+
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
+
+    assert result_count == 1
+
+
 # <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
 @mark.addons("paloalto")
 def test_palo_alto_system(record_property,  setup_splunk, setup_sc4s):
@@ -643,7 +747,7 @@ def test_palo_alto_auth_high_resolution_timestamp(record_property, setup_splunk,
     assert result_count == 1
 
 
-# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,SCTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,,,,,,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,1,1111,2905,,,,sctp,allow,0,0,0,0,vsys1,system-host,1111111,,,1111111,,2,sctp-data,sctp-init,tag1,tag2,,,,,,,,,,,,,,,,,,0,0,0,rule-uuid,2025-03-28T05:40:45.986-04:00
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,SCTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,,,,,,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1111,1,11111,2905,,,,sctp,allow,0,0,0,0,vsys1,system-host,1111111,,12345,0,medium,data,,,0x12345678,0x87654321,0,0,0,0,0,0,0,0,0,10,5,5,50,25,25,rule-uuid,2025-03-28T05:40:45.986-04:00
 @mark.addons("paloalto")
 def test_palo_alto_sctp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
@@ -675,7 +779,7 @@ def test_palo_alto_sctp(record_property, setup_splunk, setup_sc4s):
     assert result_count == 1
 
 
-# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,GTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,rule1,,,web-browsing,vsys1,trust,untrust,ethernet1/1,ethernet1/2,log-action,,1111,,1111,2152,,,,,tcp,allow,gtp-create-session,441234567890,internet.apn,lte,create-session-request,192.168.1.1,teid1,teid2,s11,0,medium,310,260,111,22222,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,60,3600,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,2025-03-28T05:40:45.986-04:00,,,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,GTP,0,,2025/03/28 05:40:45,10.0.0.1,10.0.0.2,,,rule1,,,web-browsing,vsys1,trust,untrust,ethernet1/1,ethernet1/2,Panorama-log,,1111,,11111,2152,,,,tcp,allow,gtp-create-session,441234567890,internet.apn,lte,create-session-request,192.168.1.1,teid1,teid2,s11,0,medium,310,260,12345,67890,1,,,10.0.0.0-10.255.255.255,United States,,,,,,,,0,0,,,,,,,,,,,,,,,,,2025/03/28 05:39:45,3600,tunnel-rule,10.1.1.1,user,rule-uuid,pcap-id,2025-03-28T05:40:45.986-04:00,,,management,general-internet,networking,2,has-known-vulnerability,web-browsing,no,no
 @mark.addons("paloalto")
 def test_palo_alto_gtp(record_property, setup_splunk, setup_sc4s):
     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"

--- a/tests/test_palo_alto.py
+++ b/tests/test_palo_alto.py
@@ -36,563 +36,563 @@ def get_panlc_times():
     epoch = f"{epoch_ms // 1000}.{epoch_ms % 1000:03d}"
     return bsd, time, orig_timestamp_str, epoch
 
-# # <190>Jan 28 01:28:35 PA-VM300-goran1 1,2014/01/28 01:28:35,007200001056,TRAFFIC,end,1,2014/01/28 01:28:34,192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,netbios-ns,vsys1,Trust,Untrust,ethernet1/1,ethernet1/2,To-Panorama,2014/01/28 01:28:34,8720,1,137,137,11637,137,0x400000,udp,allow,276,276,0,3,2014/01/28 01:28:02,2,any,0,2076326,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,3,0
-# @mark.addons("paloalto")
-# def test_palo_alto_traffic(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <190>Jan 28 01:28:35 PA-VM300-goran1 1,2014/01/28 01:28:35,007200001056,TRAFFIC,end,1,2014/01/28 01:28:34,192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,netbios-ns,vsys1,Trust,Untrust,ethernet1/1,ethernet1/2,To-Panorama,2014/01/28 01:28:34,8720,1,137,137,11637,137,0x400000,udp,allow,276,276,0,3,2014/01/28 01:28:02,2,any,0,2076326,0x0,192.168.0.0-192.168.255.255,192.168.0.0-192.168.255.255,0,3,0
+@mark.addons("paloalto")
+def test_palo_alto_traffic(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:34:14,000000000000,TRAFFIC,end,0000,2025/03/28 05:34:14,11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,2025/03/28 05:34:14,1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,XX-XX-XXX-XX-000X,from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2025-03-28T05:34:15.104-04:00,,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0
-# @mark.addons("paloalto")
-# def test_palo_alto_traffic_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:34:14,000000000000,TRAFFIC,end,0000,2025/03/28 05:34:14,11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,2025/03/28 05:34:14,1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,XX-XX-XXX-XX-000X,from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2025-03-28T05:34:15.104-04:00,,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0
+@mark.addons("paloalto")
+def test_palo_alto_traffic_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TRAFFIC,end,0000,{{ time }},11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,{{ time }},1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,{{ high_res_time }},,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,TRAFFIC,end,0000,{{ time }},11.111.11.111,11.111.11.111,11.111.11.111,11.111.11.111,111111-111111,,,windows-defender-atp-endpoint,vsys0,xxxxx-xxx,xxxxx_xx_xxxx,xx11.111,xx11.111,Panorama-log,{{ time }},1111111,1,11111,1111,0,0,0x111111,tcp,allow,11111,1111,1111,11,2025/03/28 05:33:55,17,url,,1111111111111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,11,11,tcp-xxx,1111,11111,1111,0,XX-XX-XXX-X-000-XXX-XXX,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,000000xx-00x0-000z-00xx-x00x00000000x,0,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,{{ high_res_time }},,,management,business-systems,client-server,1,has-known-vulnerability,windows-defender-atp,windows-defender-atp-endpoint,no,no,0\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0
-# @mark.addons("paloalto")
-# def test_palo_alto_traffic_dvc_name(
-#     record_property,  setup_splunk, setup_sc4s
-# ):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# Oct 30 09:46:12 1,2012/10/30 09:46:12,01606001116,TRAFFIC,start,1,2012/04/10 04:39:58,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:59,11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0
+@mark.addons("paloalto")
+def test_palo_alto_traffic_dvc_name(
+    record_property,  setup_splunk, setup_sc4s
+):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }}-no 1,{{ time }},007200C01056,TRAFFIC,start,1,{{ time }},192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,{{ time }},11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0,unknown,dg1,dg2,dg3,dg4,vsys_n13,{{ host }},action_source,src_vm,dest_vm,tunnel_id,tunnel_monitor_tag,tunnel_session_id,tunnel_start_time,tunnel_type\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }}-no 1,{{ time }},007200C01056,TRAFFIC,start,1,{{ time }},192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,{{ time }},11449,1,59324,80,0,0,0x200000,tcp,allow,78,78,0,1,2012/04/10 04:39:59,0,any,0,0,0x0,192.168.0.0-192.168.255.255,United States,0,1,0,unknown,dg1,dg2,dg3,dg4,vsys_n13,{{ host }},action_source,src_vm,dest_vm,tunnel_id,tunnel_monitor_tag,tunnel_session_id,tunnel_start_time,tunnel_type\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Mar 14 14:28:52 host-name 1,2025/03/14 16:28:52,111111111111111,CONFIG,0,1111,2025/03/14 16:28:40,0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,host-name,0,,0,2025-03-14T16:28:40.583+01:00
-# @mark.addons("paloalto")
-# def test_palo_alto_config_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Mar 14 14:28:52 host-name 1,2025/03/14 16:28:52,111111111111111,CONFIG,0,1111,2025/03/14 16:28:40,0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,host-name,0,,0,2025-03-14T16:28:40.583+01:00
+@mark.addons("paloalto")
+def test_palo_alto_config_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111,CONFIG,0,1111,{{ time }},0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,{{ host }},0,,0,{{ high_res_time }}\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111,CONFIG,0,1111,{{ time }},0.0.0.0,,commit-all,Panorama-admin,Panorama,Succeeded,,1111111111111111111111111,0x8000000000000000,0,0,0,0,,{{ host }},0,,0,{{ high_res_time }}\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:config"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:config"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Oct 30 09:46:17 1,2012/10/30 09:46:17,01606001116,THREAT,url,1,2012/04/10 04:39:55,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,22860,1,59303,80,0,0,0x208000,tcp,alert,"litetopdetect.cn/index.php",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html
-# @mark.addons("paloalto")
-# def test_palo_alto_threat_old_format(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <190>Oct 30 09:46:17 1,2012/10/30 09:46:17,01606001116,THREAT,url,1,2012/04/10 04:39:55,192.168.0.2,204.232.231.46,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:57,22860,1,59303,80,0,0,0x208000,tcp,alert,"litetopdetect.cn/index.php",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html
+@mark.addons("paloalto")
+def test_palo_alto_threat_old_format(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
-# # <190>Jan 28 01:28:35 fooooo 1,2020/07/08 16:48:50,013201020735,THREAT,url,2049,2020/07/08 16:48:48,10.1.1.1,1.1.1.2,1.1.1.1,1.1.1.3,URLFilter_CatchAll_Internet,testuser,,arcgis,vsys1,DMZ,Outside,ae3,ae1,Panorama-Only,2020/07/08 16:48:48,357728,1,61066,80,33396,80,0x8403000,tcp,alert,"geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?distance=100&f=json&location={""x"":-33,""y"":22.3,""spatialReference"":{""wkid"":111}}",(9999),ALL-WhitelistedURLs,informational,client-to-server,6816029286804555581,0xa000000000000000,Internal,United States,0,application/json,0,,,1,,,,,,,,0,11,16,0,0,,TESTFW01,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,
-# @mark.addons("paloalto")
-# def test_palo_alto_threat_old_format_2(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <190>Jan 28 01:28:35 fooooo 1,2020/07/08 16:48:50,013201020735,THREAT,url,2049,2020/07/08 16:48:48,10.1.1.1,1.1.1.2,1.1.1.1,1.1.1.3,URLFilter_CatchAll_Internet,testuser,,arcgis,vsys1,DMZ,Outside,ae3,ae1,Panorama-Only,2020/07/08 16:48:48,357728,1,61066,80,33396,80,0x8403000,tcp,alert,"geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?distance=100&f=json&location={""x"":-33,""y"":22.3,""spatialReference"":{""wkid"":111}}",(9999),ALL-WhitelistedURLs,informational,client-to-server,6816029286804555581,0xa000000000000000,Internal,United States,0,application/json,0,,,1,,,,,,,,0,11,16,0,0,,TESTFW01,,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0,0,4294967295,
+@mark.addons("paloalto")
+def test_palo_alto_threat_old_format_2(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},01606001116,THREAT,url,1,{{ time }},10.154.7.14,65.55.17.25,,,General Web Infrastructure,pancademo\david.poster,,web-browsing,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,ToUS1RAMA,2017/05/30 00:07:24,661375,1,1058,80,0,0,0xb000,tcp,deny,"emam.firefoxupdata.com/",(9999),malware-sites,informational,client-to-server,899904602,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,text/html,0,,,1,Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; InfoPath.1; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022),,,,,,,0,31,12,0,0,,{{ host }},,,,get,0,,0,,N/A,unknown,AppThreat-0-0,0x0\n'
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Apr 02 11:57:03 fooooo 1,2025/04/02 11:57:03,000000000000,THREAT,url,2562,2025/04/02 11:57:03,11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,2025/04/02 11:57:03,111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,XX-XX-XXX-XX-111X,,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2025-04-02T11:57:03.887-04:00,,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,
-# @mark.addons("paloalto")
-# def test_palo_alto_threat_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     """
-#     If the high-resolution timestamp is available, it should be used instead of the regular timestamp.
-#     """
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Apr 02 11:57:03 fooooo 1,2025/04/02 11:57:03,000000000000,THREAT,url,2562,2025/04/02 11:57:03,11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,2025/04/02 11:57:03,111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,XX-XX-XXX-XX-111X,,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2025-04-02T11:57:03.887-04:00,,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,
+@mark.addons("paloalto")
+def test_palo_alto_threat_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    """
+    If the high-resolution timestamp is available, it should be used instead of the regular timestamp.
+    """
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ recv_time }},00000000000,THREAT,url,2562,{{ recv_time }},11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,{{ recv_time }},111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}\}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,{{ host }},,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,{{ high_res_time }},,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,\n',
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, recv_time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ recv_time }},00000000000,THREAT,url,2562,{{ recv_time }},11.11.111.11,11.11.111.111,111.111.11.11,11.11.111.111,WEB-App,user,,web-browsing,vsys2,VCN,Internet,ae1.111,ae2.111,Panorama-log,{{ recv_time }},111111111,1,64922,443,50525,443,0x140b000,tcp,alert,"subdomain.domain.com/graphql?operationName=getAlertsNews&variables={}&extensions={""persistedQuery"":{""version"":1,""sha256Hash"":""hash""}\}",9999(9999),business-and-economy,informational,client-to-server,111111111112221111111111,0x8000000000000000,10.0.0.0-10.255.255.255,Country,,text/html,0,,,29,,,,,,,,0,13,62,2817,0,XX-XX-XXX-X-111-XXX,{{ host }},,,,options,0,,0,,N/A,N/A,AppThreat-0-0,0x0,0,1111111111111,,"business-and-economy,low-risk",xxxxx-xxxx-xxx-xxx-xxx,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,{{ high_res_time }},,,,internet-utility,general-internet,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,web-browsing,no,no,\n',
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, recv_time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netproxy host="{{ host }}" sourcetype="pan:threat"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <14>1 2020-10-09T18:39:02-04:00 paloietf.com - - - - 1,2020/10/09 17:43:54,007200001056,TRAFFIC,end,1210,2020/10/09 17:43:54,10.10.30.69,13.249.117.12,12.235.174.210,13.249.117.12,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,dvc_name,from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0
-# @mark.addons("paloalto")
-# def test_palo_alto_traffic_5424(
-#     record_property,  setup_splunk, setup_sc4s
-# ):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <14>1 2020-10-09T18:39:02-04:00 paloietf.com - - - - 1,2020/10/09 17:43:54,007200001056,TRAFFIC,end,1210,2020/10/09 17:43:54,10.10.30.69,13.249.117.12,12.235.174.210,13.249.117.12,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,dvc_name,from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0
+@mark.addons("paloalto")
+def test_palo_alto_traffic_5424(
+    record_property,  setup_splunk, setup_sc4s
+):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     iso, _, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    iso, _, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         "{{ mark }}1 {{ iso }} {{ host }} - - - - 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-#     )
-#     message = mt.render(mark="<14>", iso=iso, host=host, time=time)
+    mt = env.from_string(
+        "{{ mark }}1 {{ iso }} {{ host }} - - - - 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+    )
+    message = mt.render(mark="<14>", iso=iso, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
-# @mark.addons("paloalto")
-# def test_palo_alto_traffic_mstime(
-#     record_property,  setup_splunk, setup_sc4s
-# ):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+@mark.addons("paloalto")
+def test_palo_alto_traffic_mstime(
+    record_property,  setup_splunk, setup_sc4s
+):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-#     epoch = epoch[:-3]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+    epoch = epoch[:-3]
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007200001056,TRAFFIC,end,1210,{{ time }},192.168.41.30,192.168.41.255,10.193.16.193,192.168.41.255,allow-all,,,ssl,vsys1,trust-users,untrust,ethernet1/2.30,ethernet1/1,To-Panorama,2020/10/09 17:43:54,36459,1,39681,443,32326,443,0x400053,tcp,allow,43135,24629,18506,189,2020/10/09 16:53:27,3012,sales-laptops,0,1353226782,0x8000000000000000,10.0.0.0-10.255.255.255,United States,0,90,99,tcp-fin,16,0,0,0,,{{ host }},from-policy,,,0,,0,,N/A,0,0,0,0,ace432fe-a9f2-5a1e-327a-91fdce0077da,0\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host="{{ host }}" sourcetype="pan:traffic"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
-# # <14>May 11 10:13:22 xxxxxx 1,2020/05/11 10:13:22,015451000001111,HIPMATCH,0,2049,2020/05/11 10:13:22,xx.xx,vsys1,xx-xxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,xxxxx,1,0.0.0.0,
-# @mark.addons("paloalto")
-# def test_palo_alto_hipmatch(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <14>May 11 10:13:22 xxxxxx 1,2020/05/11 10:13:22,015451000001111,HIPMATCH,0,2049,2020/05/11 10:13:22,xx.xx,vsys1,xx-xxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,xxxxx,1,0.0.0.0,
+@mark.addons("paloalto")
+def test_palo_alto_hipmatch(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-#     epoch = epoch[:-3]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+    epoch = epoch[:-3]
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},015451000001111,HIPMATCH,0,2049,{{ time }},xxxx.xxx,vsys1,xx-xxxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,{{ host }},1,0.0.0.0,\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},015451000001111,HIPMATCH,0,2049,{{ time }},xxxx.xxx,vsys1,xx-xxxxxx-MB,Mac,10.252.31.187,GP-HIP,1,profile,0,0,1052623,0x0,17,11,12,0,,{{ host }},1,0.0.0.0,\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Mar 28 05:40:45 system-host 1,2025/04/02 17:55:34,1111111111111111111,HIPMATCH,0,1111,2025/04/02 17:55:28,user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,XXXXXXXXXXXX,1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,2025-04-02T17:55:28.942+02:00
-# @mark.addons("paloalto")
-# def test_palo_alto_hipmatch_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Mar 28 05:40:45 system-host 1,2025/04/02 17:55:34,1111111111111111111,HIPMATCH,0,1111,2025/04/02 17:55:28,user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,XXXXXXXXXXXX,1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,2025-04-02T17:55:28.942+02:00
+@mark.addons("paloalto")
+def test_palo_alto_hipmatch_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},1111111111111111111,HIPMATCH,0,1111,{{ time }},user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,{{ host }},1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,{{ high_res_time }}\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},1111111111111111111,HIPMATCH,0,1111,{{ time }},user@mail.com,vsys1,XXXXXXXXXXXXX,Windows,11.111.111.1,HIP-Compliant-Client,1,profile,,,111111111111111111,0x8000000000000000,13,330,29982,0,,{{ host }},1,0.0.0.0,xxx-xxx-xxx-xxx-xxx,xxxx,,{{ high_res_time }}\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=epintel host="{{ host }}" sourcetype="pan:hipmatch"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# @mark.addons("paloalto")
-# def test_palo_alto_globalprotect(
-#     record_property,  setup_splunk, setup_sc4s
-# ):
-#     get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     orig_host = get_host_name()
-#     overwritten_host_name = get_host_name()
+@mark.addons("paloalto")
+def test_palo_alto_globalprotect(
+    record_property,  setup_splunk, setup_sc4s
+):
+    get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    orig_host = get_host_name()
+    overwritten_host_name = get_host_name()
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-#     tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,2023-11-09T16:39:17.223+01:00,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
-#         + "\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,2023-11-09T16:39:17.223+01:00,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
+        + "\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netfw host={{ overwritten_host_name }} sourcetype="pan:globalprotect"'
-#     )
-#     search = st.render(epoch=epoch, overwritten_host_name=overwritten_host_name)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netfw host={{ overwritten_host_name }} sourcetype="pan:globalprotect"'
+    )
+    search = st.render(epoch=epoch, overwritten_host_name=overwritten_host_name)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", overwritten_host_name)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", overwritten_host_name)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
-# # <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
-# @mark.addons("paloalto")
-# def test_palo_alto_system(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
+@mark.addons("paloalto")
+def test_palo_alto_system(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }}'
-#         + "\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }}'
+        + "\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <14>1 2026-03-18T08:30:10+01:00 testpanorama01.customer.com - - - - 1,2026/03/18 08:30:10,000702196763,SYSTEM,monitoring,0,2026/03/18 08:30:10,,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,testpanorama01,0,0,2026-03-18T08:30:10.000+01:00
-# @mark.addons("paloalto")
-# def test_palo_alto_system_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <14>1 2026-03-18T08:30:10+01:00 testpanorama01.customer.com - - - - 1,2026/03/18 08:30:10,000702196763,SYSTEM,monitoring,0,2026/03/18 08:30:10,,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,testpanorama01,0,0,2026-03-18T08:30:10.000+01:00
+@mark.addons("paloalto")
+def test_palo_alto_system_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000702196763,SYSTEM,monitoring,0,{{ time }},,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,{{ host }},0,0,{{ high_res_time }}\n'
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000702196763,SYSTEM,monitoring,0,{{ time }},,deviating-device, ,0,0,general,informational,"Deviating device: KLTPA01, Serial: 111111111111, Object: interface 1/5, Metric: rx-errors, Value: 91172",7595638036506897317,0x0,0,0,0,0,,{{ host }},0,0,{{ high_res_time }}\n'
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,device-name,1,,2025/03/28 05:40:45,1,0x0,a111111,,2025-03-28T05:40:45.986-04:00
-# @mark.addons("paloalto")
-# def test_palo_alto_userid_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,device-name,1,,2025/03/28 05:40:45,1,0x0,a111111,,2025-03-28T05:40:45.986-04:00
+@mark.addons("paloalto")
+def test_palo_alto_userid_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,{{ host }},1,,2025/03/28 05:40:45,1,0x0,a111111,,{{ high_res_time }}\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},000000000000,USERID,login,0000,2025/03/28 05:40:45,vsys0,11.111.11.111,usr,,0,1,10800,0,0,vpn-client,globalprotect,0000000000000000000,0x8000000000000000,11,11,1111,0,virtual-system-name,{{ host }},1,,2025/03/28 05:40:45,1,0x0,a111111,,{{ high_res_time }}\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:userid"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netauth host="{{ host }}" sourcetype="pan:userid"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
-# @mark.addons("paloalto")
-# def test_palo_alto_system_futureproof(
-#     record_property,  setup_splunk, setup_sc4s
-# ):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <190>Jan 23 00:45:02 panw-system-host 1,2021/01/23 00:45:03,012001003714,SYSTEM,userid,0,2021/01/22 18:00:10,,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,XXX_UK_GLA_PAXXX
+@mark.addons("paloalto")
+def test_palo_alto_system_futureproof(
+    record_property,  setup_splunk, setup_sc4s
+):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }},something'
-#         + "\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},012001006066,SYSTEM,USERID,0,{{ time }},,connect-ldap-sever-failure,xxx.xxx.xxx.109,0,0,general,medium,"ldap cfg blue-uxxxx-ldap-gm failed to connect to server xxx.xxx.xxx.109 xxx.xxx.xxx.xxx connect to xxx.xxx.xxx.xxx(xxx.xxx.xxx.xxx):636",6837908,0x8000000000000000,0,0,0,0,,{{ host }},something'
+        + "\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:system"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
-# # <14>1 2023-07-06T19:20:22+00:00 DEVICE_NAME 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no
-# @mark.addons("paloalto")
-# def test_palo_alto_decryption(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+# <14>1 2023-07-06T19:20:22+00:00 DEVICE_NAME 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no
+@mark.addons("paloalto")
+def test_palo_alto_decryption(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
 
-#     dt = datetime.datetime.now(datetime.timezone.utc)
-#     _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, time, _, _, _, epoch = time_operations(dt)
 
-#     # Tune time functions
-#     time = dt.strftime("%Y/%m/%d %H:%M:%S")
-#     epoch = epoch[:-7]
+    # Tune time functions
+    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    epoch = epoch[:-7]
 
-#     mt = env.from_string(
-#         '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no\n'
-#     )
-#     message = mt.render(mark="<14>", bsd=bsd, host=host, time=time)
+    mt = env.from_string(
+        '{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},007XXXXX341044,DECRYPTION,0,2562,{{ time }},XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,XXX.XXX.XXX.XXX,AWS Services by URL - Egress,,,incomplete,vsys1,Default Zone,Default Zone,ethernet1/1,ethernet1/1,ANONYMIZED,{{ time }},504326,1,37612,443,0,0,0x1000000,tcp,allow,N/A,,,,,ANONYMIZED,Server_Hello_Done,Client_Hello,TLS1.2,ECDHE,AES_128_GCM,SHA256,ANONYMIZED,secp256r1,Certificate,trusted,Trusted,Forward,ANONYMIZED,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,[DATE], [DATE],V3,2048,12,45,34,18,:::::RSA,*.badssl.com,ANONYMIZED,ANONYMIZED,expired.badssl.com,Received fatal alert CertificateExpired from client. CA Issuer URL (truncated):ANONYMIZED,[DATE-TIME],,,,,,,,,,ANONYMIZED,0x8000000000000000,29,82,454,0,,ANONYMIZED,1,unknown,unknown,unknown,1,,,incomplete,no,no\n'
+    )
+    message = mt.render(mark="<14>", bsd=bsd, host=host, time=time)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
-# # <190>Mar 28 05:40:45 system-host 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,2025-04-02T15:56:19.287+00:00,,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,ssl,no,no
-# @mark.addons("paloalto")
-# def test_palo_alto_decryption_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
-#     host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
-#     bsd, time, orig_timestamp_str, epoch = get_panlc_times()
+# <190>Mar 28 05:40:45 system-host 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,2025-04-02T15:56:19.287+00:00,,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use",,ssl,no,no
+@mark.addons("paloalto")
+def test_palo_alto_decryption_high_resolution_timestamp(record_property,  setup_splunk, setup_sc4s):
+    host = f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
-#     mt = env.from_string(
-#         "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,{{ high_res_time }},,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no\n"
-#     )
-#     message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
+    mt = env.from_string(
+        "{{ mark }} {{ bsd }} {{ host }} 1,{{ time }},111111111111111111111,DECRYPTION,0,2562,{{ time }},11.11.111.111,11.11.111.111,11.111.1.11,11.11.111.111,external-access,,,ssl,vsys1,XXX1,Internet,ethernet1/1,ethernet1/2,Log_Forwarding_Profile_XX,{{ time }},111111111,1,1111111,443,38178,443,0x400400,tcp,allow,N/A,,,,,xxxxxx-xxxxx-xxxxx-xxxx-xxxxxxx,Certificate,Certificate,TLS1.2,ECDHE,AES_128_GCM,SHA256,external-access,,None,uninspected,Uninspected,No Decrypt,xxxxx,xxxxxxxx,2025/02/10 15:21:54,2028/02/10 15:21:54,V3,2048,34,27,0,0,:::::RSA,url.com,Intermediate CA,,,,,,,,,,,{{ high_res_time }},,,,,,,,,,,,,,,,,xxx,xxx,20,0,0,0,,xx-xx-firewall-xx,1,encrypted-tunnel,networking,browser-based,4,\"used-by-malware,able-to-transfer-file,has-known-vulnerability,tunnel-other-application,pervasive-use\",,ssl,no,no\n"
+    )
+    message = mt.render(mark="<111>", bsd=bsd, host=host, time=time, high_res_time=orig_timestamp_str)
 
-#     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
+    sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 
-#     st = env.from_string(
-#         'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
-#     )
-#     search = st.render(epoch=epoch, host=host)
+    st = env.from_string(
+        'search _time={{ epoch }} index=netops host="{{ host }}" sourcetype="pan:decryption"'
+    )
+    search = st.render(epoch=epoch, host=host)
 
-#     result_count, _ = splunk_single(setup_splunk, search)
+    result_count, _ = splunk_single(setup_splunk, search)
 
-#     record_property("host", host)
-#     record_property("resultCount", result_count)
-#     record_property("message", message)
+    record_property("host", host)
+    record_property("resultCount", result_count)
+    record_property("message", message)
 
-#     assert result_count == 1
+    assert result_count == 1
 
 
 # <190>Mar 28 05:40:45 system-host 1,2025/03/28 05:40:45,000000000000,GLOBALPROTECT,0,2561,2025/03/28 05:40:45,vsys1,gateway-logout,logout,,,USERNAME,XX,MACHINENAME,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,HOSTID,SERIAL,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,PORTALNAME,GATEWAY,0x8000000000000000,2025-03-28T05:40:45.986-04:00,,,,,,13,19,52,450,,system-host,1

--- a/tests/test_palo_alto.py
+++ b/tests/test_palo_alto.py
@@ -385,19 +385,13 @@ def test_palo_alto_globalprotect(
     orig_host = get_host_name()
     overwritten_host_name = get_host_name()
 
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, tzoffset, _, epoch = time_operations(dt)
-
-    # Tune time functions
-    time = dt.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-    tzoffset = tzoffset[0:3] + ":" + tzoffset[3:]
-    epoch = epoch[:-7]
+    bsd, time, orig_timestamp_str, epoch = get_panlc_times()
 
     mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,2023-11-09T16:39:17.223+01:00,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
+        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,{{ high_res_time }},,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
         + "\n"
     )
-    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
+    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name, high_res_time=orig_timestamp_str)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 

--- a/tests/test_palo_alto.py
+++ b/tests/test_palo_alto.py
@@ -414,22 +414,28 @@ def test_palo_alto_globalprotect(
 def test_palo_alto_globalprotect_old_format(
     record_property, setup_splunk, setup_sc4s
 ):
-    """Verify old-format GLOBALPROTECT logs (no high_res_time) fall back to time_generated."""
+    """Verify old-format GLOBALPROTECT logs (no high_res_time) fall back to time_generated.
+    Uses a time_generated 15 minutes behind BSD header so only time_generated can match epoch.
+    """
     get_host_name = lambda: f"{shortuuid.ShortUUID().random(length=5).lower()}-{shortuuid.ShortUUID().random(length=5).lower()}"
     orig_host = get_host_name()
     overwritten_host_name = get_host_name()
 
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    _, bsd, time, _, _, _, epoch = time_operations(dt)
+    dt_now = datetime.datetime.now(datetime.timezone.utc)
+    _, bsd, bsd_time, _, _, _, _ = time_operations(dt_now)
+    bsd_time = dt_now.strftime("%Y/%m/%d %H:%M:%S")
 
-    time = dt.strftime("%Y/%m/%d %H:%M:%S")
+    # time_generated is 15 minutes behind BSD — only time_generated can match epoch
+    dt_past = dt_now - datetime.timedelta(minutes=15)
+    _, _, time_generated, _, _, _, epoch = time_operations(dt_past)
+    time_generated = dt_past.strftime("%Y/%m/%d %H:%M:%S")
     epoch = epoch[:-7]
 
     mt = env.from_string(
-        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
+        '{{ mark }} {{ bsd }} {{ orig_host }} 1,{{ bsd_time }},XXXXXXXXXXXXXXXXXX,GLOBALPROTECT,0,2561,{{ time_generated }},vsys1,gateway-logout,logout,,,XXXXXXXX,XX,XXXXXXXXXXXXXX,8.8.8.8,0.0.0.0,192.0.0.1,0.0.0.0,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXXXXXX,5.2.12,Windows,"Microsoft Windows 10 Enterprise , 64-bit",1,,,"client logout",success,,1554,,0,XXXXXXXXXXXXXXXXXXXX,XXXXXXXXXXXXXXXX,0x8000000000000000,,,,,,,13,19,52,450,,{{ overwritten_host_name }},1'
         + "\n"
     )
-    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, time=time, overwritten_host_name=overwritten_host_name)
+    message = mt.render(mark="<111>", bsd=bsd, orig_host=orig_host, bsd_time=bsd_time, time_generated=time_generated, overwritten_host_name=overwritten_host_name)
 
     sendsingle(message, setup_sc4s[0], setup_sc4s[1][514])
 


### PR DESCRIPTION
PAN (Palo Alto Networks) syslog timestamps don't include timezone information by default, which causes inaccurate event timestamps in Splunk. Starting from newer PAN-OS versions, a high_res_time field was added in each log entry.
PR #2728 introduced parsing of `high_res_time` for 5 log types: THREAT, TRAFFIC, CONFIG, HIPMATCH, USERID. This PR extends that fix to the remaining log types.

FYI: https://splunk.atlassian.net/browse/ADDON-77075

**Changes to app-syslog-pan_panos.conf**

**GLOBALPROTECT** : The existing parser already had a field at position 37 named event_time, which PAN-OS docs label "High Resolution Timestamp". It was never mapped to high_res_time so the shared date-parser at the bottom of the block never picked it up. Converted to if/elif pattern, renaming that field to high_res_time so the timestamp is now correctly parsed.

**AUTH**: Same issue as GLOBALPROTECT. The field at position 34 was named timestamp instead of high_res_time. Converted to if/elif pattern with the correct field name.

**SCTP, GTP, TUNNEL INSPECTION**: These three log types had no parser at all in sc4s. New parser blocks added based on PAN-OS 10.2 field documentation, with high_res_time. Field counts verified against the official docs.

**Log types not requiring parser changes**

- URL, DATA FILTERING Subtypes of THREAT (log_subtype=url/data). Already handled by THREAT parser from PR #2728.
- IPTAG Subtype of USERID (log_subtype=Iptag). Already handled by USERID parser from PR #2728.
- DECRYPT Already updated in PR #2728 as DECRYPTION.
- SYSTEM Already updated in this codebase (SYSTEM parser has if/elif with high_res_time).
- CORRELATED EVENTS PAN-OS docs confirm this log type has no high_res_time field.
- AUDIT Subtype of SYSTEM (log_subtype=AUDIT). Handled by SYSTEM parser. No high_res_time field per PAN-OS docs.

**New tests added (tests/test_palo_alto.py)**

test_palo_alto_globalprotect_high_resolution_timestamp
test_palo_alto_auth_high_resolution_timestamp
test_palo_alto_sctp
test_palo_alto_gtp
test_palo_alto_tunnel

Each test sends a log with a high_res_time offset 15 minutes behind the syslog header timestamp, then verifies the event lands in Splunk at _time matching the high_res_time value. confirming that the high-precision timestamp takes priority over the BSD header time.