### PR TITLE
feat: added config setting for listen status host

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,9 +344,11 @@ ExecStart=/usr/bin/podman run \
         --name SC4S \
         --rm $SC4S_IMAGE
 ```
-# Change your status port
+# Change your status host and port
 
 Use `SC4S_LISTEN_STATUS_PORT` to change the "status" port used by the internal health check process. The default value is `8080`.
+
+Use `SC4S_LISTEN_STATUS_HOST` to change the network interface the internal health check process binds to. The default value is `0.0.0.0`, which binds to all interfaces so the health endpoint is reachable by container orchestrators (for example, Kubernetes liveness/readiness probes and Docker port mappings). If you only need local access, set this to `127.0.0.1` to restrict the endpoint to the local interface.
 
 # Parallelize
 Use the parallelize feature to manage TCP congestion when using single heavy-data streams.

--- a/package/sbin/healthcheck.py
+++ b/package/sbin/healthcheck.py
@@ -29,6 +29,7 @@ def get_list_of_destinations():
     return set(found_destinations)
 
 class Config:
+    HEALTHCHECK_HOST = os.getenv('SC4S_LISTEN_STATUS_HOST', '0.0.0.0')
     HEALTHCHECK_PORT = int(os.getenv('SC4S_LISTEN_STATUS_PORT', '8080'))
     CHECK_QUEUE_SIZE = str_to_bool(os.getenv('HEALTHCHECK_CHECK_QUEUE_SIZE', "false"))
     MAX_QUEUE_SIZE = int(os.getenv('HEALTHCHECK_MAX_QUEUE_SIZE', '10000'))
@@ -131,4 +132,4 @@ def healthcheck():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=Config.HEALTHCHECK_PORT)
+    app.run(host=Config.HEALTHCHECK_HOST, port=Config.HEALTHCHECK_PORT)


### PR DESCRIPTION
Addresses the `Avoid binding the application to all network interfaces` security issue: now this is available as a configurable option instead of hardcoded 0.0.0.0 host.