### PR TITLE
fix: Fix NAME cache IPv4/IPv6 key collisions and IPv6 SQLite overflow

### DIFF
--- a/package/shared/pylib/parser_source_cache.py
+++ b/package/shared/pylib/parser_source_cache.py
@@ -1,3 +1,4 @@
+import ipaddress
 import traceback
 import socket
 import struct
@@ -45,6 +46,12 @@ def int2ip(addr):
         return int_to_ip6(addr)
 
 
+def ip_cache_key(addr):
+    ip = ipaddress.ip_address(addr)
+    prefix = "v4" if ip.version == 4 else "v6"
+    return f"{prefix}:{ip}"
+
+
 hostdict = str("/var/lib/syslog-ng/hostip")
 
 
@@ -60,10 +67,10 @@ class psc_parse(LogParser):
     def parse(self, log_message):
         try:
             ipaddr = log_message.get_as_str("SOURCEIP", "", repr="internal")
-            ip_int = ip2int(ipaddr)
-            self.logger.debug(f"psc.parse sourceip={ipaddr} int={ip_int}")
+            ip_key = ip_cache_key(ipaddr)
+            self.logger.debug(f"psc.parse sourceip={ipaddr} key={ip_key}")
             try:
-                name = self.db[ip_int]
+                name = self.db[ip_key]
             except KeyError:
                 return False
             self.logger.debug(f"psc.parse host={name}")
@@ -120,20 +127,20 @@ class psc_dest(LogDestination):
                 return self.SUCCESS
 
             try:
-                ip_int = ip2int(ipaddr)
-            except OSError:
+                ip_key = ip_cache_key(ipaddr)
+            except ValueError:
                 self.logger.debug(
                     f"psc.send skipped: invalid SOURCEIP sourceip={ipaddr!r}"
                 )
                 return self.SUCCESS
 
             try:
-                current = self.db[ip_int]
+                current = self.db[ip_key]
             except KeyError:
-                self.db[ip_int] = host
+                self.db[ip_key] = host
             else:
                 if current != host:
-                    self.db[ip_int] = host
+                    self.db[ip_key] = host
         except Exception:
             self.logger.debug(traceback.format_exc())
             return self.ERROR

--- a/tests/test_cache_destinations.py
+++ b/tests/test_cache_destinations.py
@@ -120,7 +120,7 @@ def test_name_cache_new_entry_is_published_only_when_batch_is_flushed(
     assert destination.init({}) is True
     assert destination.open() is True
     reader = SqliteDict(database_file, outer_stack=False)
-    database_key = 3221225986
+    database_key = "v4:192.0.2.2"
 
     try:
         result = destination.send(
@@ -153,7 +153,7 @@ def test_name_cache_changed_entry_is_published_only_after_flush(
     )
     assert destination.init({}) is True
     assert destination.open() is True
-    database_key = 3221225986
+    database_key = "v4:192.0.2.2"
     destination.db[database_key] = "old-cache-host"
     destination.db.commit()
     reader = SqliteDict(database_file, outer_stack=False)

--- a/tests/test_cache_parsers.py
+++ b/tests/test_cache_parsers.py
@@ -57,7 +57,7 @@ def test_name_cache_miss_preserves_message_without_logging_traceback():
 
 
 def test_name_cache_hit_applies_cached_host():
-    parser = make_name_cache_parser({3221225994: "cache-host"})
+    parser = make_name_cache_parser({"v4:192.0.2.10": "cache-host"})
     message = LogMessage(
         {
             "SOURCEIP": "192.0.2.10",
@@ -73,7 +73,7 @@ def test_name_cache_hit_applies_cached_host():
 
 
 def test_name_cache_unexpected_hit_failure_logs_traceback():
-    parser = make_name_cache_parser({3221225994: "cache-host"})
+    parser = make_name_cache_parser({"v4:192.0.2.10": "cache-host"})
     message = RejectingLogMessage(
         {
             "SOURCEIP": "192.0.2.10",


### PR DESCRIPTION
The NAME cache was converting SOURCEIP to a plain integer before storing it as a SQLite key. This caused two bugs:

- Key collision: 0.0.0.1 and ::1 both produce integer 1, so they shared the same cache row and could overwrite each other's hostname.
- IPv6 failure: Most IPv6 addresses require 128 bits, exceeding SQLite's signed 64-bit integer limit, causing an OverflowError on write.

Fix: Replace the integer key with a family-tagged string (v4:192.0.2.2, v6:2001:db8::1) generated by ip_cache_key() using Python's ipaddress module. This guarantees no cross-family collisions and stores safely as a string in SQLite. Existing caches will cold-repopulate under the new key namespace; operators can use SC4S_CLEAR_NAME_CACHE=yes for a one-time cleanup on upgrade.
